### PR TITLE
Address multiple typos

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,7 +1,7 @@
 INSTALLATION INSTRUCTIONS FOR OSPD
 ==================================
 
-Please note: The reference system used by most of the developers is Debian
+Please note: The reference system used by most of the developers is
 Debian GNU/Linux 'Stretch' 9. The build might fail on any other systems.
 Also it is necessary to install dependent development packages.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ About OSPD
 
 OSPD is a base class for scanner wrappers which share the same communication
 protocol: OSP (Open Scanner Protocol). OSP creates a unified interface for
-different security scanners and make their control flow and scan results
+different security scanners and makes their control flow and scan results
 consistently available under the central Greenbone Vulnerability Manager service.
 
 OSP is similar in many ways to GMP (Greenbone Management Protocol): XML-based,

--- a/doc/INSTALL-ospd-scanner
+++ b/doc/INSTALL-ospd-scanner
@@ -76,7 +76,7 @@ create your own one (can be used for multiple ospd daemons):
 $ gvm-manage-certs.sh -s
 
 And sign it with the CA checked for by the client. The client is usually
-Greenbone Vulnerability Manager for which a global trusted CA certficate
+Greenbone Vulnerability Manager for which a global trusted CA certificate
 can be configured.
 
 

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -261,7 +261,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </pattern>
     </response>
     <example>
-      <summary>Delete a scan successfuly</summary>
+      <summary>Delete a scan successfully</summary>
       <request>
         <delete_scan scan_id="013587e3-b4d7-8e79-9ebb-90a2133c338c"/>
       </request>
@@ -585,7 +585,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </parameter_type>
   <parameter_type>
     <name>selection</name>
-    <summary>A value out of the | seperated values list</summary>
+    <summary>A value out of the | separated values list</summary>
   </parameter_type>
   <parameter_type>
     <name>credential_up</name>

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -226,7 +226,7 @@ class ResultType(object):
 
 __inet_pton = None
 def inet_pton(address_family, ip_string):
-    """ A platform independant version of inet_pton """
+    """ A platform independent version of inet_pton """
     global __inet_pton
     if __inet_pton is None:
         if hasattr(socket, 'inet_pton'):
@@ -239,7 +239,7 @@ def inet_pton(address_family, ip_string):
 
 __inet_ntop = None
 def inet_ntop(address_family, packed_ip):
-    """ A platform independant version of inet_ntop """
+    """ A platform independent version of inet_ntop """
     global __inet_ntop
     if __inet_ntop is None:
         if hasattr(socket, 'inet_ntop'):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -246,7 +246,7 @@ class OSPDaemon(object):
         # @todo: Actually it makes sense to move the certificate params to
         #        a separate function because it is not mandatory anymore to
         #        use a TLS setup (unix file socket is an alternative).
-        #        However, chaning this makes it mandatory for any ospd scanner
+        #        However, changing this makes it mandatory for any ospd scanner
         #        to change the function calls as well. So this breaks the API
         #        and should only be done with a major release.
         self.certs = dict()
@@ -346,7 +346,7 @@ class OSPDaemon(object):
         return params
 
     def process_scan_params(self, params):
-        """ This method is to be overriden by the child classes if necessary
+        """ This method is to be overridden by the child classes if necessary
         """
         return params
 
@@ -659,7 +659,7 @@ class OSPDaemon(object):
         return txt
 
     def elements_as_text(self, elems, indent=2):
-        """ Returns the elems dictionnary as formatted plain text. """
+        """ Returns the elems dictionary as formatted plain text. """
         assert elems
         text = ""
         for elename, eledesc in elems.items():
@@ -669,7 +669,7 @@ class OSPDaemon(object):
             elif isinstance(eledesc, str):
                 desc_txt = ''.join([eledesc, '\n'])
             else:
-                assert False, "Only string or dictionnary"
+                assert False, "Only string or dictionary"
             ele_txt = "\t{0}{1: <22} {2}".format(' ' * indent, elename,
                                                  desc_txt)
             text = ''.join([text, ele_txt])
@@ -719,7 +719,7 @@ class OSPDaemon(object):
     def get_xml_str(self, data):
         """ Creates a string in XML Format using the provided data structure.
 
-        @param: Dictionnary of xml tags and their elements.
+        @param: Dictionary of xml tags and their elements.
 
         @return: String of data in xml format.
         """
@@ -857,7 +857,7 @@ class OSPDaemon(object):
                     self.handle_client_stream(client_stream, False)
                 close_client_stream(client_stream, unix_path)
         except KeyboardInterrupt:
-            logger.info("Recieved Ctrl-C shuting-down ...")
+            logger.info("Received Ctrl-C shutting-down ...")
         finally:
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     ],
 
     # What does your project relate to?
-    keywords=['Greenbone Vulnerbility Manager OSP'],
+    keywords=['Greenbone Vulnerability Manager OSP'],
 
     # List run-time dependencies here. These will be installed by pip when your
     # project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
This commit fixes a number of spelling mistakes, mainly in documentation
and log messages.