### PR TITLE
Add OSP command get_vts.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -5,9 +5,10 @@ Description: OSP schema with embedded documentation, in OSP.
 
 Authors:
 Hani Benhabiles <hani.benhabiles@greenbone.net>
+Jan-Oliver Wagner <jan-oliver.wagner@greenbone.net>
 
 Copyright:
-Copyright (C) 2014, 2015 Greenbone Networks GmbH
+Copyright (C) 2014, 2015, 2018 Greenbone Networks GmbH
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -28,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <name>Open Scanner Protocol</name>
   <abbreviation>OSP</abbreviation>
   <summary>The Open Scanner Protocol</summary>
-  <version>1.1</version>
+  <version>1.2</version>
   <type>
     <name>integer</name>
     <summary>An integer</summary>
@@ -473,6 +474,86 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </response>
     </example>
   </command>
+
+  <command>
+    <name>get_vts</name>
+    <summary>Return information about vulnerability tests, if offered by scanner</summary>
+    <pattern>
+      <attrib>
+        <name>vt_id</name>
+        <summary>Identifier for vulnerability test</summary>
+        <type>string</type>
+      </attrib>
+    </pattern>
+    <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>integer</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        <e>vts</e>
+      </pattern>
+      <ele>
+        <name>vts</name>
+        <pattern>
+          <any><e>vt</e></any>
+        </pattern>
+        <ele>
+          <name>vt</name>
+          <pattern>
+            <attrib>
+              <name>id</name>
+              <type>string</type>
+            </attrib>
+            <e>name</e>
+          </pattern>
+          <ele>
+            <name>name</name>
+          </ele>
+        </ele>
+      </ele>
+    </response>
+    <example>
+      <summary>Get information for all available vulnerability tests</summary>
+      <request>
+        <get_vts/>
+      </request>
+      <response>
+        <get_vts_response status_text="OK" status="200">
+          <vts>
+            <vt id="1.2.3.4.5">
+              <name>Check for presence of vulnerabilty X</name>
+            </vt>
+            <vt id="ad45h67">
+              <name>Check for presence of vulnerabilty Y</name>
+            </vt>
+          </vts>
+        </get_vts_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get information for a single vulnerability test</summary>
+      <request>
+        <get_vts id='1.2.3.4.5'/>
+      </request>
+      <response>
+        <get_vts_response status_text="OK" status="200">
+          <vts>
+            <vt id="1.2.3.4.5">
+              <name>Check for presence of vulnerabilty X</name>
+            </vt>
+          </vts>
+        </get_vts_response>
+      </response>
+    </example>
+  </command>
+
   <command>
     <name>start_scan</name>
     <summary>Start a new scan</summary>
@@ -599,6 +680,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <name>ovaldef_file</name>
     <summary>An ovaldef file's content that is base64 encoded</summary>
   </parameter_type>
+
+  <change>
+    <command>GET_VTS</command>
+    <summary>command added</summary>
+    <description>
+      Added new command to retrieve information about vulnerability tests a scanner might offer.
+    </description>
+    <version>1.2</version>
+  </change>
+
   <change>
     <command>STOP_SCAN</command>
     <summary>command added</summary>

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -63,6 +63,25 @@ class FullTest(unittest.TestCase):
         response = ET.fromstring(daemon.handle_command('<get_version />'))
         print(ET.tostring(response))
 
+    def testGetVTs_no_VT(self):
+        daemon = DummyWrapper([])
+        response = ET.fromstring(daemon.handle_command('<get_vts />'))
+        print(ET.tostring(response))
+
+    def testGetVTs_single_VT(self):
+        daemon = DummyWrapper([])
+        daemon.add_vt('1.2.3.4', 'A vulnerability test')
+        response = ET.fromstring(daemon.handle_command('<get_vts />'))
+        print(ET.tostring(response))
+
+    def testGetVTs_multiple_VTs(self):
+        daemon = DummyWrapper([])
+        daemon.add_vt('1.2.3.4', 'A vulnerability test')
+        daemon.add_vt('some id', 'Another vulnerability test')
+        daemon.add_vt('123456789', 'Yet another vulnerability test')
+        response = ET.fromstring(daemon.handle_command('<get_vts />'))
+        print(ET.tostring(response))
+
     def testiScanWithError(self):
         daemon = DummyWrapper([
             Result('error', value='something went wrong'),


### PR DESCRIPTION
This adds the command get_vts, for getting the list and details about
vulnerability tests a OSP scanner might offer.

So far, the tests have only an id and a name. It is intended
to extend this by some standard elements which are shared among
different scanners and with individual elements which are very specific
for a scanner.

With this status, it would be possible to have a client get the list and
allow the user to select one or many tests that are desired.

Follow-ups will be to add receive the vt selection from the client in
order to execute only these.

This change uses a simple dict for storage. With extending
capabilities, it might be helpful to use advanced containers/collections.

* ospd/ospd.py: Add command get_vts and handling of data. Increase version
  of OSP to 1.2.

* doc/OSP.xml: Add documentation for command get_vts.