### PR TITLE
Add a Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![CircleCI](https://circleci.com/gh/greenbone/ospd/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/ospd/tree/master)
+[![Codecov](https://img.shields.io/codecov/c/github/greenbone/ospd.svg)](https://codecov.io/gh/greenbone/ospd)
 
 About OSPD
 ----------


### PR DESCRIPTION
This commit adds a badge showing the current code coverage of the unit
tests in the master branch based on the analysis provided by Codecov.