### PR TITLE
Add optional custom elements for VT information.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -512,9 +512,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <type>string</type>
             </attrib>
             <e>name</e>
+            <e>custom</e>
           </pattern>
           <ele>
             <name>name</name>
+          </ele>
+          <ele>
+            <name>custom</name>
           </ele>
         </ele>
       </ele>
@@ -547,6 +551,25 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <vts>
             <vt id="1.2.3.4.5">
               <name>Check for presence of vulnerabilty X</name>
+            </vt>
+          </vts>
+        </get_vts_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get information for a vulnerability test with custom data</summary>
+      <request>
+        <get_vts id='1.2.3.4.5'/>
+      </request>
+      <response>
+        <get_vts_response status_text="OK" status="200">
+          <vts>
+            <vt id="1.2.3.4.5">
+              <name>Check for presence of vulnerabilty X</name>
+	      <custom>
+                <my_element>First custom element</my_element>
+                <my_other_element>second custom element</my_other_element>
+	      </custom>
             </vt>
           </vts>
         </get_vts_response>

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -29,6 +29,9 @@ class DummyWrapper(OSPDaemon):
     def check(self):
         return self.checkresults
 
+    def get_custom_vt_as_xml_str(self, custom):
+        return '<mytest>static test</mytest>'
+
     def exec_scan(self, scan_id, target):
         time.sleep(0.01)
         for res in self.results:
@@ -83,6 +86,14 @@ class FullTest(unittest.TestCase):
         daemon = DummyWrapper([])
         daemon.add_vt('1.2.3.4', 'A vulnerability test')
         daemon.add_vt('some id', 'Another vulnerability test')
+        daemon.add_vt('123456789', 'Yet another vulnerability test')
+        response = ET.fromstring(daemon.handle_command('<get_vts />'))
+        print(ET.tostring(response))
+
+    def testGetVTs_multiple_VTs_with_custom(self):
+        daemon = DummyWrapper([])
+        daemon.add_vt('1.2.3.4', 'A vulnerability test')
+        daemon.add_vt('some id', 'Another vulnerability test with custom info', { 'depencency': '1.2.3.4' })
         daemon.add_vt('123456789', 'Yet another vulnerability test')
         response = ET.fromstring(daemon.handle_command('<get_vts />'))
         print(ET.tostring(response))


### PR DESCRIPTION
This allows osdp scanners to add arbitrary custom elements to a VT
information.
Some elements such as "name" (some more in the future) are
predefined. But some scanners might need to manage addtional
and very individual elements.

ospd-based scanners can use add_vt() to add (optionally) also custom data.
Next, they can implement the function get_custom_vt_as_xml_str() to
create a xml string represenation of whatever the custom content is.