### PR TITLE
Fix inadvertently redefined test

### DIFF
--- a/tests/testArgumentsParser.py
+++ b/tests/testArgumentsParser.py
@@ -53,7 +53,6 @@ class testArgumentParser(unittest.TestCase):
         args = get_common_args(self.parser, '-k /etc/passwd'.split())
         self.assertEqual('/etc/passwd', args['keyfile'])
 
-    
-    def testDefaultLogLevel(self):
+    def testDefaultKey(self):
         args = get_common_args(self.parser, [])
         self.assertEqual(misc.KEY_FILE, args['keyfile'])


### PR DESCRIPTION
This commit changes the method name for a tests to better reflect the
test subject and to stop overriding the test with the same method name.