### PR TITLE
Update tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
-envlist=py27, py33, py34, pypy
+envlist=py35, py36, pypy
+skip_missing_interpreters=True
 [testenv]
 commands={envpython} setup.py test


### PR DESCRIPTION
This commit updates the list of environments which should be tested with
`tox`. It also allows `tox` to succeed if not all interpreters are
available in the build environment.