### PR TITLE
Allow clients to choose TLS versions > 1.0

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -508,13 +508,19 @@ class OSPDaemon(object):
         newsocket, fromaddr = sock.accept()
         logger.debug("New connection from"
                      " {0}:{1}".format(fromaddr[0], fromaddr[1]))
+        # NB: Despite the name, ssl.PROTOCOL_SSLv23 selects the highest
+        # protocol version that both the client and server support. In modern
+        # Python versions (>= 3.4) it suppports TLS >= 1.0 with SSLv2 and SSLv3
+        # being disabled. For Python >=3.5, PROTOCOL_SSLv23 is an alias for
+        # PROTOCOL_TLS which should be used once compatibility with Python 3.4
+        # is no longer desired.
         try:
             ssl_socket = ssl.wrap_socket(newsocket, cert_reqs=ssl.CERT_REQUIRED,
                                          server_side=True,
                                          certfile=self.certs['cert_file'],
                                          keyfile=self.certs['key_file'],
                                          ca_certs=self.certs['ca_file'],
-                                         ssl_version=ssl.PROTOCOL_TLSv1)
+                                         ssl_version=ssl.PROTOCOL_SSLv23)
         except (ssl.SSLError, socket.error) as message:
             logger.error(message)
             return None


### PR DESCRIPTION
This commit allows OSP clients to negotiate a TLS version higher than
TLSv1.0 instead of forcing them to use this specific protocol version
which may be subject to protocol-specific weaknesses depending on the
environment.

As the comment explains, the constant `ssl.PROTOCOL_SSLv23` does indeed
select the highest protocol version that both the client and server
support for current Python versions (>= 3.4), despite its name.

If compatibility with Python 3.4 is no longer desired, the slightly more
fitting constant `ssl.PROTOCOL_TLS` should be used.