### PR TITLE
Add element "vts" to parameters for starting scans

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -52,6 +52,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <summary>A date, in unix format</summary>
     <pattern>integer</pattern>
   </type>
+  <type>
+    <name>vt_id</name>
+    <summary>Identifier for a vulnerability test</summary>
+    <pattern>xsd:token { pattern = "[0-9a-zA-Z_.:]{1,80}" }</pattern>
+  </type>
   <command>
     <name>help</name>
     <summary>Get the help text</summary>
@@ -482,7 +487,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <attrib>
         <name>vt_id</name>
         <summary>Identifier for vulnerability test</summary>
-        <type>string</type>
+        <type>vt_id</type>
       </attrib>
     </pattern>
     <response>
@@ -509,7 +514,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <pattern>
             <attrib>
               <name>id</name>
-              <type>string</type>
+              <type>vt_id</type>
             </attrib>
             <e>name</e>
             <e>custom</e>
@@ -638,7 +643,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         </start_scan_response>
       </response>
     </example>
+    <example>
+      <summary>Start a new scan with a VT selection</summary>
+      <request>
+        <start_scan target='localhost' ports='80, 443'>
+          <scanner_params>
+            <vts>1.2.3.4.5, 22.34.61.1, 3.67.4.2</vts>
+          </scanner_params>
+        </start_scan>
+      </request>
+      <response>
+        <start_scan_response status_text="OK" status="200">
+          <id>2f616d53-595f-4785-9b97-4395116ca118</id>
+        </start_scan_response>
+      </response>
+    </example>
   </command>
+
   <command>
     <name>stop_scan</name>
     <summary>Stop a currently running scan</summary>

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -55,7 +55,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <type>
     <name>vt_id</name>
     <summary>Identifier for a vulnerability test</summary>
-    <pattern>xsd:token { pattern = "[0-9a-zA-Z_.:]{1,80}" }</pattern>
+    <pattern>xsd:token { pattern = "[0-9a-zA-Z_\-.:]{1,80}" }</pattern>
   </type>
   <command>
     <name>help</name>

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -286,7 +286,7 @@ class OSPDaemon(object):
         for name, param in BASE_SCANNER_PARAMS.items():
             self.add_scanner_param(name, param)
         self.vts = dict()
-        self.vt_id_pattern = re.compile("[0-9a-zA-Z_:.]{1,80}")
+        self.vt_id_pattern = re.compile("[0-9a-zA-Z_\-:.]{1,80}")
 
     def set_command_attributes(self, name, attributes):
         """ Sets the xml attributes of a specified command. """

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -38,6 +38,7 @@ import ssl
 import multiprocessing
 import xml.etree.ElementTree as ET
 import os
+import re
 
 from ospd import __version__
 from ospd.misc import ScanCollection, ResultType, target_str_to_list
@@ -61,6 +62,13 @@ BASE_SCANNER_PARAMS = {
         'default': 0,
         'mandatory': 0,
         'description': 'Whether to dry run scan.',
+    },
+    'vts': {
+        'type': 'string',
+        'name': 'Vulnerability Tests',
+        'default': '',
+        'mandatory': 0,
+        'description': 'Comma-separated list of vulnerability test IDs to be executed.',
     },
 }
 
@@ -275,9 +283,10 @@ class OSPDaemon(object):
         self.protocol_version = PROTOCOL_VERSION
         self.commands = COMMANDS_TABLE
         self.scanner_params = dict()
-        self.vts = dict()
         for name, param in BASE_SCANNER_PARAMS.items():
             self.add_scanner_param(name, param)
+        self.vts = dict()
+        self.vt_id_pattern = re.compile("[0-9a-zA-Z_:.]{1,80}")
 
     def set_command_attributes(self, name, attributes):
         """ Sets the xml attributes of a specified command. """
@@ -306,6 +315,9 @@ class OSPDaemon(object):
         """
 
         if not vt_id:
+            return -2 # no valid vt_id
+
+        if self.vt_id_pattern.fullmatch(vt_id) is None:
             return -2 # no valid vt_id
 
         if vt_id in self.vts:


### PR DESCRIPTION
The element "vts" is added to the base scanner parameters
and allows to send a list of vt's to be executed by the scanner.

The scanner needs to parse and handle the list on its own.

Since "vts" is a comma-separated list of vt_ids, to prevent
parsing/escaping problems, the syntax of a vt_id is now
limited to certain characters which are typically used for ids.