### PR TITLE
Remove tox configuration file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,0 @@
-[tox]
-envlist=py35, py36, pypy
-skip_missing_interpreters=True
-[testenv]
-commands={envpython} setup.py test


### PR DESCRIPTION
This commit removes the `tox.ini` file intended for use with the `tox`
testing framework.

While testing with multiple Python versions is indeed an important task,
the `tox` approach of expecting an (CI) environment to provide multiple
Python interpreters is somewhat cumbersome and better served by using
completely separate environment for various Python versions.