### PR TITLE
Extend <get_vts> with params.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -517,10 +517,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <type>vt_id</type>
             </attrib>
             <e>name</e>
+            <e>vt_params</e>
             <e>custom</e>
           </pattern>
           <ele>
             <name>name</name>
+          </ele>
+          <ele>
+            <name>vt_params</name>
           </ele>
           <ele>
             <name>custom</name>
@@ -571,6 +575,37 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <vts>
             <vt id="1.2.3.4.5">
               <name>Check for presence of vulnerabilty X</name>
+	      <custom>
+                <my_element>First custom element</my_element>
+                <my_other_element>second custom element</my_other_element>
+	      </custom>
+            </vt>
+          </vts>
+        </get_vts_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get information for a vulnerability test with VT parameters data</summary>
+      <request>
+        <get_vts id='1.2.3.4.5'/>
+      </request>
+      <response>
+        <get_vts_response status_text="OK" status="200">
+          <vts>
+            <vt id="1.2.3.4.5">
+              <name>Check for presence of vulnerabilty X</name>
+	      <vt_params>
+                <vt_param id="timeout" type="integer">
+                  <name>Timeout</name>
+                  <description>Vulnerability Test Timeout</description>
+                  <default>300</default>
+                </vt_param>
+                <vt_param id="scan.udp" type="boolean">
+                  <name>Scan UDP</name>
+                  <description />
+                  <default>1</default>
+                </vt_param>
+	      </vt_params>
 	      <custom>
                 <my_element>First custom element</my_element>
                 <my_other_element>second custom element</my_other_element>

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -298,7 +298,7 @@ class OSPDaemon(object):
             'scanner_params':
                 {k: v['name'] for k, v in self.scanner_params.items()}}
 
-    def add_vt(self, vt_id, name='', custom=None):
+    def add_vt(self, vt_id, name='', vt_params=None, custom=None):
         """ Add a vulnerability test information.
 
         Returns: The new number of stored VTs.
@@ -308,18 +308,19 @@ class OSPDaemon(object):
         """
 
         if not vt_id:
-            return -2 # no valid vt_id
+            return -2  # no valid vt_id
 
         if self.vt_id_pattern.fullmatch(vt_id) is None:
-            return -2 # no valid vt_id
+            return -2  # no valid vt_id
 
         if vt_id in self.vts:
-            return -1 # The VT was already in the list.
+            return -1  # The VT was already in the list.
 
-        if vt_id and custom is not None:
-            self.vts[vt_id] = { 'name': name, 'custom': custom }
-        else:
-            self.vts[vt_id] = { 'name': name }
+        self.vts[vt_id] = {'name': name}
+        if custom is not None:
+            self.vts[vt_id]["custom"] = custom
+        if vt_params is not None:
+            self.vts[vt_id]["vt_params"] = vt_params
 
         return len(self.vts)
 
@@ -854,6 +855,19 @@ class OSPDaemon(object):
         """
         return ''
 
+    def get_params_vt_as_xml_str(self, vt_params):
+        """ Create a string representation of the XML object from the
+        vt_params data object.
+        This needs to be implemented by each ospd wrapper, in case
+        vt_params elements for VTs are used.
+
+        The vt_params XML object which is returned will be embedded
+        into a <vt_params></vt_params> element.
+
+        @return: XML object as string for vt parameters data.
+        """
+        return ''
+
     def get_vt_xml(self, vt_id):
         """ Gets a single vulnerability test information in XML format.
 
@@ -875,6 +889,10 @@ class OSPDaemon(object):
         if vt.get('custom'):
             custom_xml_str = '<custom>%s</custom>' % self.get_custom_vt_as_xml_str(vt.get('custom'))
             vt_xml.append(ET.fromstring(custom_xml_str))
+
+        if vt.get('vt_params'):
+            params_xml_str = '<vt_params>%s</vt_params>' % self.get_params_vt_as_xml_str(vt.get('vt_params'))
+            vt_xml.append(ET.fromstring(params_xml_str))
 
         return vt_xml
 

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -32,6 +32,14 @@ class DummyWrapper(OSPDaemon):
     def get_custom_vt_as_xml_str(self, custom):
         return '<mytest>static test</mytest>'
 
+    def get_params_vt_as_xml_str(self, vt_param):
+        return ('<vt_param id="abc" type="string">'
+                '<name>ABC</name><description>Test ABC</description><default>yes</default>'
+                '</vt_param>'
+                '<vt_param id="def" type="string">'
+                '<name>DEF</name><description>Test DEF</description><default>no</default>'
+                '</vt_param>')
+
     def exec_scan(self, scan_id, target):
         time.sleep(0.01)
         for res in self.results:
@@ -97,6 +105,25 @@ class FullTest(unittest.TestCase):
         daemon.add_vt('123456789', 'Yet another vulnerability test')
         response = ET.fromstring(daemon.handle_command('<get_vts />'))
         print(ET.tostring(response))
+
+    def testGetVTs_VTs_with_params(self):
+        daemon = DummyWrapper([])
+        daemon.add_vt('1.2.3.4', 'A vulnerability test', vt_params="a", custom="b")
+        response = ET.fromstring(daemon.handle_command('<get_vts vt_id="1.2.3.4"></get_vts>'))
+        print(ET.tostring(response))
+        # The status of the response must be success (i.e. 200)
+        self.assertEqual(response.get('status'), '200')
+        # The response root element must have the correct name
+        self.assertEqual(response.tag, 'get_vts_response')
+        # The response must contain a 'scanner_params' element
+        self.assertIsNotNone(response.find('vts'))
+        vt_params =  response[0][0].findall('vt_params')
+        self.assertEqual(1, len(vt_params))
+        custom =  response[0][0].findall('custom')
+        self.assertEqual(1, len(custom))
+        params = response.findall('vts/vt/vt_params/vt_param')
+        self.assertEqual(2, len(params))
+
 
     def testiScanWithError(self):
         daemon = DummyWrapper([


### PR DESCRIPTION
Add a new subelement <vt_params>. As with custom, the content must be
formated by the wrapper.
Update documentation.
Add Unittest.