### PR TITLE
Start with param

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -645,7 +645,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>vts</name>
-      <summary>Vulnerability test list to be excecute</summary>
+      <summary>Contanins elements that represent Vulnerability Test to be excecute and their parameters</summary>
     </ele>
     <response>
       <pattern>
@@ -684,11 +684,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </response>
     </example>
     <example>
-      <summary>Start a new scan with a VT selection</summary>
+      <summary>Start a new scan with a VT selection and VT's parameters</summary>
       <request>
         <start_scan target='localhost' ports='80, 443'>
           <scanner_params />
-          <vts>1.2.3.4.5, 22.34.61.1, 3.67.4.2</vts>
+          <vts>
+            <vt id='1.3.6.1.4.1.25623.1.0.10662'>
+              <vt_param name='XYZ JKL' type='entry'>200</vt_param>
+              <vt_param name='ABC' type='checkbox'>yes</vt_param>
+            </vt>
+            <vt id='1.3.6.1.4.1.25623.1.0.10330'></vt>
+            <vt id='1.3.6.1.4.1.25623.1.0.100034'></vt>
+          </vts>
         </start_scan>
       </request>
       <response>
@@ -777,7 +784,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <summary>vts optional element added </summary>
     <description>
       Added optional element vts to allow the client to specify a vts list
-      to use for the scan.
+      to use for the scan and their parameters.
     </description>
     <version>1.2</version>
   </change>

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -388,12 +388,29 @@ class OSPDaemon(object):
         return params
 
     def process_vts_params(self, scanner_vts):
-        """ Process the scan vts and their parameters.
+        """ Receive an XML object with the Vulnerability Tests an their
+        parameters to be use in a scan and return a dictionary.
+
+        @param: XML element with vt subelements. Each vt has an
+                id attribute. Optinal parameters can be included
+                as vt child.
+                Example form:
+                <vts>
+                  <vt id='vt1' />
+                  <vt id='vt2'>
+                    <vt_param name='param1' type='type'>value</vt_param>
+                  </vt>
+                <vts>
+
+        @return: Dictionary containing the vts attribute and subelements,
+                 like the VT's id and VT's parameters.
+                 Example form:
+                 {v1, vt2: {param1: {'type': type', 'value': value}}}
         """
         vts = {}
         for vt in scanner_vts:
-            id = vt.attrib.get('id')
-            vts[id] = {}
+            vt_id = vt.attrib.get('id')
+            vts[vt_id] = {}
             for param in vt:
                 if not param.attrib.get('name'):
                     raise OSPDError('Invalid NVT parameter. No parameter name',
@@ -401,7 +418,7 @@ class OSPDaemon(object):
                 ptype = param.attrib.get('type', 'entry')
                 pvalue = param.text if param.text else ''
                 pname = param.attrib.get('name')
-                vts[id][pname] = {'type': ptype, 'value': pvalue}
+                vts[vt_id][pname] = {'type': ptype, 'value': pvalue}
         return vts
 
     def handle_start_scan_command(self, scan_et):


### PR DESCRIPTION
Add vts params to start_scan as a vt subelement.
Now each vt is a subelement of <vts>. It has an id attribute. Each vt accept multiple optional vt_param as subelements, with name and type as attribute and the value as text.
Update example for start_scan with vts parameters.
Add unittest to test VTs as elements and VT's parameters.