### PR TITLE
Add <targets> element to <start_scan>.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -128,8 +128,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <start_scan>
             <attributes>
               <scan_id>Optional UUID value to set as scan ID</scan_id>
-              <target>Target host to scan</target>
-              <ports>Ports list to scan</ports>
+              <target>Target hosts to scan in a comma-separated list</target>
+              <ports>Ports list to scan as comma-separated list</ports>
             </attributes>
             <elements>
               <scanner_params>
@@ -575,10 +575,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <vts>
             <vt id="1.2.3.4.5">
               <name>Check for presence of vulnerabilty X</name>
-	      <custom>
+              <custom>
                 <my_element>First custom element</my_element>
                 <my_other_element>second custom element</my_other_element>
-	      </custom>
+              </custom>
             </vt>
           </vts>
         </get_vts_response>
@@ -594,7 +594,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <vts>
             <vt id="1.2.3.4.5">
               <name>Check for presence of vulnerabilty X</name>
-	      <vt_params>
+              <vt_params>
                 <vt_param id="timeout" type="integer">
                   <name>Timeout</name>
                   <description>Vulnerability Test Timeout</description>
@@ -605,11 +605,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                   <description />
                   <default>1</default>
                 </vt_param>
-	      </vt_params>
-	      <custom>
+              </vt_params>
+              <custom>
                 <my_element>First custom element</my_element>
                 <my_other_element>second custom element</my_other_element>
-	      </custom>
+              </custom>
             </vt>
           </vts>
         </get_vts_response>
@@ -623,12 +623,12 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <pattern>
       <attrib>
         <name>target</name>
-        <summary>Target host to scan</summary>
+        <summary>Target hosts to scan in a comma-separated list</summary>
         <type>string</type>
       </attrib>
       <attrib>
         <name>ports</name>
-        <summary>Ports list to scan</summary>
+        <summary>Ports list to scan as comma-separated list</summary>
         <type>string</type>
       </attrib>
       <attrib>
@@ -646,6 +646,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <ele>
       <name>vts</name>
       <summary>Contanins elements that represent Vulnerability Test to be excecute and their parameters</summary>
+    </ele>
+    <ele>
+      <name>targets</name>
+      <summary>Contanins elements that represent a target to execute a scan against. If target and port attributes are present this elemen is not take in account</summary>
     </ele>
     <response>
       <pattern>
@@ -696,6 +700,35 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <vt id='1.3.6.1.4.1.25623.1.0.10330'></vt>
             <vt id='1.3.6.1.4.1.25623.1.0.100034'></vt>
           </vts>
+        </start_scan>
+      </request>
+      <response>
+        <start_scan_response status_text="OK" status="200">
+          <id>2f616d53-595f-4785-9b97-4395116ca118</id>
+        </start_scan_response>
+      </response>
+    </example>
+    <example>
+      <summary>Start a new scan with multi-targets</summary>
+      <request>
+        <start_scan>
+          <scanner_params />
+          <vts>
+            <vt id='1.3.6.1.4.1.25623.1.0.10662'>
+              <vt_param name='XYZ JKL' type='entry'>200</vt_param>
+              <vt_param name='ABC' type='checkbox'>yes</vt_param>
+            </vt>
+          </vts>
+          <targets>
+            <target>
+              <hosts>localhost</hosts>
+              <ports>80,443</ports>
+            </target>
+            <target>
+              <hosts>192.168.1.0/24</hosts>
+              <ports>1,2,3,80,443</ports>
+            </target>
+          </targets>
         </start_scan>
       </request>
       <response>
@@ -785,6 +818,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <description>
       Added optional element vts to allow the client to specify a vts list
       to use for the scan and their parameters.
+    </description>
+    <version>1.2</version>
+  </change>
+  <change>
+    <command>START_SCAN</command>
+    <summary>target optional element added </summary>
+    <description>
+      Added optional element targets to specify different hosts with a different port list. This is take in account only if target and port attributes are not present in start_scan tag.
     </description>
     <version>1.2</version>
   </change>

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -116,7 +116,7 @@ class ScanCollection(object):
 
         return iter(self.scans_table.keys())
 
-    def create_scan(self, scan_id='', target='', ports='', options=dict(), vts=''):
+    def create_scan(self, scan_id='', targets='', options=dict(), vts=''):
         """ Creates a new scan with provided scan information. """
 
         if self.data_manager is None:
@@ -124,8 +124,7 @@ class ScanCollection(object):
         scan_info = self.data_manager.dict()
         scan_info['results'] = list()
         scan_info['progress'] = 0
-        scan_info['target'] = target
-        scan_info['ports'] = ports
+        scan_info['targets'] = targets
         scan_info['vts'] = vts
         scan_info['options'] = options
         scan_info['start_time'] = int(time.time())
@@ -162,14 +161,23 @@ class ScanCollection(object):
         return self.scans_table[scan_id]['end_time']
 
     def get_target(self, scan_id):
-        """ Get a scan's target. """
+        """ Get a scan's target list. """
 
-        return self.scans_table[scan_id]['target']
+        return self.scans_table[scan_id]['targets']
 
-    def get_ports(self, scan_id):
-        """ Get a scan's ports list. """
-
-        return self.scans_table[scan_id]['ports']
+    def get_ports(self, scan_id, target):
+        """ Get a scan's ports list. If a target is specified
+        it will return the corresponding port for it. If not,
+        it returns the port item of the first nested list in
+        the target's list.
+        """
+        port = None
+        if target:
+            for item in self.scans_table[scan_id]['targets']:
+                if target == item[0]:
+                    return item[1]
+                    break
+        return self.scans_table[scan_id]['targets'][0][1]
 
     def get_vts(self, scan_id):
         """ Get a scan's vts list. """

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -171,12 +171,11 @@ class ScanCollection(object):
         it returns the port item of the first nested list in
         the target's list.
         """
-        port = None
         if target:
             for item in self.scans_table[scan_id]['targets']:
                 if target == item[0]:
                     return item[1]
-                    break
+
         return self.scans_table[scan_id]['targets'][0][1]
 
     def get_vts(self, scan_id):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -422,7 +422,8 @@ class OSPDaemon(object):
                 vts[vt_id][pname] = {'type': ptype, 'value': pvalue}
         return vts
 
-    def process_targets_element(self, scanner_target):
+    @staticmethod
+    def process_targets_element(scanner_target):
         """ Receive an XML object with the target, ports to run
         a scan against.
 

--- a/tests/testSSHDaemon.py
+++ b/tests/testSSHDaemon.py
@@ -48,7 +48,7 @@ class TestSSH(unittest.TestCase):
     def testRunCommand(self):
         ospd_ssh.paramiko = fakeparamiko
         daemon = OSPDaemonSimpleSSH('cert', 'key', 'ca')
-        scanid = daemon.create_scan(None, 'host.example.com', '80, 443',
+        scanid = daemon.create_scan(None, ['host.example.com', '80, 443'],
                                     dict(port=5, ssh_timeout=15,
                                          username_password='dummy:pw'), '')
         res = daemon.run_command(scanid, 'host.example.com', 'cat /etc/passwd')

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -266,6 +266,4 @@ class FullTest(unittest.TestCase):
                                   '<ports>22</ports></target></targets>' +
                                   '</start_scan>'))
         print(ET.tostring(response))
-        scan_id = response.findtext('id')
-        time.sleep(0.01)
         self.assertEqual(response.get('status'), '200')

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -251,3 +251,21 @@ class FullTest(unittest.TestCase):
                ' <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">' +
                ']>')
         self.assertRaises(EntitiesForbidden, daemon.handle_command, lol)
+
+    def testScanMultiTarget(self):
+        daemon = DummyWrapper([])
+        response = secET.fromstring(
+            daemon.handle_command('<start_scan>' +
+                                  '<scanner_params /><vts><vt id="1.2.3.4" />' +
+                                  '</vts>' +
+                                  '<targets><target>' +
+                                  '<hosts>localhosts</hosts>' +
+                                  '<ports>80,443</ports>' +
+                                  '</target>' +
+                                  '<target><hosts>192.168.0.0/24</hosts>' +
+                                  '<ports>22</ports></target></targets>' +
+                                  '</start_scan>'))
+        print(ET.tostring(response))
+        scan_id = response.findtext('id')
+        time.sleep(0.01)
+        self.assertEqual(response.get('status'), '200')


### PR DESCRIPTION
It is possible now to specify different ports for different targets,
and run them all from the same task.
Each target, which can be a multi-host target, may have its own port list.
For this reason, get_scan_ports() receive the optional parameter 'target',
to return the corresponding port list for this target. In other case it
returns the port list of the first target for all targets.

For backward compatibility purposes it is still allow to pass a
target list and a port list as attributes, in which case the <targets>
element will be ignored. As before, exec_scan is called for each host
and the port list is the same for each host.

Document <targets> in start_scan and add example. Document compatibility changes
Add unittest.