### PR TITLE
Improve OSP protocol documentation

### DIFF
--- a/doc/HTML.xsl
+++ b/doc/HTML.xsl
@@ -20,7 +20,7 @@ Authors:
 Hani Benhabiles <hani.benhabiles@greenbone.net>
 
 Copyright:
-Copyright (C) 2014 Greenbone Networks GmbH
+Copyright (C) 2014, 2018 Greenbone Networks GmbH
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License
@@ -486,7 +486,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                   </pre>
                 </xsl:for-each>
               </div>
-              <i>OSPD</i>
+              <i>Server</i>
               <div style="margin-left: 2%; margin-right: 2%;">
                 <xsl:for-each select="response/*">
                   <pre>

--- a/doc/HTML.xsl
+++ b/doc/HTML.xsl
@@ -37,6 +37,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 -->
 
+  <xsl:variable name="rnc-comments">0</xsl:variable>
+  <xsl:include href="rnc.xsl"/>
+
   <!-- Helpers. -->
 
   <xsl:template name="newline">
@@ -265,7 +268,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:template>
 
   <xsl:template match="type" mode="details">
-    <xsl:param name="index">3.<xsl:value-of select="position()"/></xsl:param>
+    <xsl:param name="index">4.<xsl:value-of select="position()"/></xsl:param>
     <div>
       <div>
         <h3 id="type_{name}">
@@ -283,11 +286,72 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:template>
 
   <xsl:template name="type-details">
-    <h2 id="type_details">3 Data Types Details</h2>
+    <h2 id="type_details">4 Data Types Details</h2>
     <xsl:apply-templates select="type" mode="details"/>
   </xsl:template>
 
+  <!-- Elements. -->
+
+  <xsl:template match="element" mode="index">
+    <tr id="index">
+      <td id="index"><a href="#element_{name}"><xsl:value-of select="name"/></a></td>
+      <td id="index">
+        <xsl:if test="summary">
+          <div style="margin-left: 15px;"><xsl:value-of select="normalize-space(summary)"/>.</div>
+        </xsl:if>
+      </td>
+    </tr>
+  </xsl:template>
+
+  <xsl:template name="element-summary">
+    <h2 id="element_summary">2 Summary of Elements</h2>
+    <table id="index">
+    <xsl:apply-templates select="element" mode="index"/>
+    </table>
+  </xsl:template>
+
+  <xsl:template name="element-details">
+    <h2 id="element_details">5 Element Details</h2>
+    <xsl:apply-templates select="element"/>
+  </xsl:template>
+
+  <xsl:template match="element">
+    <xsl:param name="index">5.<xsl:value-of select="position()"/></xsl:param>
+    <div>
+      <div>
+        <h3 id="element_{name}">
+        <xsl:value-of select="$index"/>
+        Element <tt><xsl:value-of select="name"/></tt></h3>
+      </div>
+
+      <p>In short: <xsl:value-of select="normalize-space(summary)"/>.</p>
+
+      <xsl:apply-templates select="description"/>
+
+      <h4><xsl:value-of select="$index"/>.1 Structure</h4>
+
+      <ul style="list-style: none">
+        <li>
+          <xsl:call-template name="command-structure"/>
+        </li>
+      </ul>
+
+      <h4><xsl:value-of select="$index"/>.2 RNC</h4>
+
+      <div style="border: 1px solid; padding:10px; width: 85%; align: center; margin-left: auto; margin-right: auto; background: #d5d5d5;">
+        <div style="margin-left: 5%">
+          <xsl:call-template name="command-relax"/>
+        </div>
+      </div>
+
+    </div>
+  </xsl:template>
+
   <!-- Commands. -->
+
+  <xsl:template name="command-relax">
+    <pre><xsl:call-template name="command-body"/></pre>
+  </xsl:template>
 
   <xsl:template match="type">
     <xsl:choose>
@@ -445,7 +509,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:template>
 
   <xsl:template match="command">
-    <xsl:param name="index">4.<xsl:value-of select="position()"/></xsl:param>
+    <xsl:param name="index">6.<xsl:value-of select="position()"/></xsl:param>
     <div>
       <div>
         <h3 id="command_{name}">
@@ -512,19 +576,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </xsl:template>
 
   <xsl:template name="command-summary">
-    <h2 id="command_summary">2 Summary of Commands</h2>
+    <h2 id="command_summary">3 Summary of Commands</h2>
     <table>
     <xsl:apply-templates select="command" mode="index"/>
     </table>
   </xsl:template>
 
   <xsl:template name="command-details">
-    <h2 id="command_details">4 Command Details</h2>
+    <h2 id="command_details">6 Command Details</h2>
     <xsl:apply-templates select="command"/>
   </xsl:template>
 
   <xsl:template name="parameter-summary">
-    <h2 id="parameter_summary">5 Summary of Scanner Parameters Types</h2>
+    <h2 id="parameter_summary">7 Summary of Scanner Parameters Types</h2>
     <table>
     <xsl:apply-templates select="parameter_type" mode="index"/>
     </table>
@@ -533,7 +597,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <!-- Changes. -->
 
   <xsl:template match="change">
-    <xsl:param name="index">6.<xsl:value-of select="position()"/></xsl:param>
+    <xsl:param name="index">8.<xsl:value-of select="position()"/></xsl:param>
     <div>
       <div>
         <h3>
@@ -550,7 +614,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
   <xsl:template name="changes">
     <h2 id="changes">
-      6 Compatibility Changes in Version <xsl:value-of select="/protocol/version"/>
+      8 Compatibility Changes in Version <xsl:value-of select="/protocol/version"/>
     </h2>
     <xsl:apply-templates select="change[version=/protocol/version]"/>
   </xsl:template>
@@ -597,8 +661,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                 <h2 id="contents">Contents</h2>
                 <ol>
                   <li><a href="#type_summary">Summary of Data Types</a></li>
+                  <li><a href="#element_summary">Summary of Elements</a></li>
                   <li><a href="#command_summary">Summary of Commands</a></li>
                   <li><a href="#type_details">Data Type Details</a></li>
+                  <li><a href="#element_details">Element Details</a></li>
                   <li><a href="#command_details">Command Details</a></li>
                   <li><a href="#parameter_summary">Summary of Scanner Parameters Types</a></li>
                   <li>
@@ -609,8 +675,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                 </ol>
 
                 <xsl:call-template name="type-summary"/>
+                <xsl:call-template name="element-summary"/>
                 <xsl:call-template name="command-summary"/>
                 <xsl:call-template name="type-details"/>
+                <xsl:call-template name="element-details"/>
                 <xsl:call-template name="command-details"/>
                 <xsl:call-template name="parameter-summary"/>
                 <xsl:call-template name="changes"/>

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -30,6 +30,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <abbreviation>OSP</abbreviation>
   <summary>The Open Scanner Protocol</summary>
   <version>1.2</version>
+
+  <!-- Types. -->
+
   <type>
     <name>integer</name>
     <summary>An integer</summary>
@@ -57,6 +60,28 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <summary>Identifier for a vulnerability test</summary>
     <pattern>xsd:token { pattern = "[0-9a-zA-Z_\-.:]{1,80}" }</pattern>
   </type>
+
+  <!-- Elements. -->
+
+  <element>
+    <name>target</name>
+    <summary>A scan target consisting of hosts and a port selection</summary>
+    <pattern>
+      <e>hosts</e>
+      <e>ports</e>
+    </pattern>
+    <ele>
+      <name>hosts</name>
+      <summary>One or many hosts. The list is comma-separated. Each entry can be a IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6</summary>
+    </ele>
+    <ele>
+      <name>ports</name>
+      <summary>A list of ports that is the same for the given hosts</summary>
+    </ele>
+  </element>
+
+  <!-- Commands. -->
+
   <command>
     <name>help</name>
     <summary>Get the help text</summary>

--- a/doc/rnc.xsl
+++ b/doc/rnc.xsl
@@ -1,0 +1,469 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:str="http://exslt.org/strings"
+    extension-element-prefixes="str">
+  <xsl:strip-space elements="*"/>
+
+<!--
+OSPD
+$Id$
+Description: Open Scanner Protocol (OSP) RNC support templates.
+
+Authors:
+Matthew Mundell <matthew.mundell@greenbone.net>
+
+Copyright:
+Copyright (C) 2010, 2018 Greenbone Networks GmbH
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+-->
+
+  <!-- Helpers. -->
+
+<!-- This is called within a PRE. -->
+<xsl:template name="wrap">
+  <xsl:param name="string"></xsl:param>
+
+  <xsl:choose>
+    <xsl:when test="contains($string, '&#10;')">
+      <xsl:for-each select="str:tokenize($string, '&#10;')">
+        <xsl:call-template name="wrap-line">
+          <xsl:with-param name="string"><xsl:value-of select="."/></xsl:with-param>
+        </xsl:call-template>
+        <xsl:text>
+</xsl:text>
+      </xsl:for-each>
+    </xsl:when>
+    <xsl:otherwise>
+      <xsl:call-template name="wrap-line">
+        <xsl:with-param name="string"><xsl:value-of select="$string"/></xsl:with-param>
+      </xsl:call-template>
+    </xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+<!-- This is called within a PRE. -->
+<xsl:template name="wrap-line">
+  <xsl:param name="string"></xsl:param>
+
+  <xsl:variable name="to-next-newline">
+    <xsl:value-of select="substring-before($string, '&#10;')"/>
+  </xsl:variable>
+
+  <xsl:choose>
+    <xsl:when test="string-length($string) = 0">
+      <!-- The string is empty. -->
+    </xsl:when>
+    <xsl:when test="(string-length($to-next-newline) = 0) and (substring($string, 1, 1) != '&#10;')">
+      <!-- A single line missing a newline, output up to the edge. -->
+<xsl:value-of select="substring($string, 1, 76)"/>
+      <xsl:if test="string-length($string) &gt; 76">&#8629;
+<xsl:call-template name="wrap-line">
+  <xsl:with-param name="string"><xsl:value-of select="substring($string, 77, string-length($string))"/></xsl:with-param>
+</xsl:call-template>
+      </xsl:if>
+    </xsl:when>
+    <xsl:when test="(string-length($to-next-newline) + 1 &lt; string-length($string)) and (string-length($to-next-newline) &lt; 76)">
+      <!-- There's a newline before the edge, so output the line. -->
+<xsl:value-of select="substring($string, 1, string-length($to-next-newline) + 1)"/>
+<xsl:call-template name="wrap-line">
+  <xsl:with-param name="string"><xsl:value-of select="substring($string, string-length($to-next-newline) + 2, string-length($string))"/></xsl:with-param>
+</xsl:call-template>
+    </xsl:when>
+    <xsl:otherwise>
+      <!-- Any newline comes after the edge, so output up to the edge. -->
+<xsl:value-of select="substring($string, 1, 76)"/>
+      <xsl:if test="string-length($string) &gt; 76">&#8629;
+<xsl:call-template name="wrap-line">
+  <xsl:with-param name="string"><xsl:value-of select="substring($string, 77, string-length($string))"/></xsl:with-param>
+</xsl:call-template>
+      </xsl:if>
+    </xsl:otherwise>
+  </xsl:choose>
+
+</xsl:template>
+
+  <!-- Preamble. -->
+
+  <xsl:template name="preamble">
+    <xsl:text>### Preamble
+
+start = command | response
+
+command
+  = </xsl:text>
+    <xsl:for-each select="command">
+      <xsl:value-of select="name"/>
+      <xsl:if test="following-sibling::command">
+        <xsl:call-template name="newline"/>
+        <xsl:text>    | </xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:text>
+
+response
+  = </xsl:text>
+    <xsl:for-each select="command">
+      <xsl:value-of select="name"/>
+      <xsl:text>_response</xsl:text>
+      <xsl:if test="following-sibling::command">
+        <xsl:call-template name="newline"/>
+        <xsl:text>    | </xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+    <xsl:call-template name="newline"/>
+  </xsl:template>
+
+  <!-- Commands. -->
+
+  <xsl:template name="rnc-type">
+    <xsl:choose>
+      <xsl:when test="count (alts) &gt; 0">
+        <xsl:for-each select="alts/alt">
+          <xsl:choose>
+            <xsl:when test="following-sibling::alt and preceding-sibling::alt">
+              <xsl:text>|</xsl:text>
+              <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:when test="count (following-sibling::alt) = 0">
+              <xsl:text>|</xsl:text>
+              <xsl:value-of select="."/>
+              <xsl:text>" }</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>xsd:token { pattern = "</xsl:text>
+              <xsl:value-of select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="normalize-space(text())"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="attrib" match="attrib">
+    <xsl:if test="($rnc-comments = 1) and summary">
+      <xsl:text># </xsl:text>
+      <xsl:value-of select="normalize-space(summary)"/>
+      <xsl:text>.</xsl:text>
+      <xsl:call-template name="newline"/>
+      <xsl:text>       </xsl:text>
+    </xsl:if>
+    <xsl:text>attribute </xsl:text>
+    <xsl:value-of select="name"/>
+    <xsl:text> { </xsl:text>
+    <xsl:for-each select="type">
+      <xsl:call-template name="rnc-type"/>
+    </xsl:for-each>
+    <xsl:text> }</xsl:text>
+    <xsl:choose>
+      <xsl:when test="required=1"></xsl:when>
+      <xsl:otherwise><xsl:text>?</xsl:text></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="c" match="c">
+    <xsl:value-of select="text()"/>
+  </xsl:template>
+
+  <xsl:template name="e" match="e">
+    <xsl:param name="parent-name"/>
+    <xsl:param name="parent"/>
+    <xsl:variable name="name" select="text()"/>
+    <xsl:choose>
+      <xsl:when test="$parent/ele[name=$name]">
+        <xsl:value-of select="$parent-name"/>
+        <xsl:value-of select="$name"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <!-- Presume there is a top level element with this name. -->
+        <xsl:value-of select="$name"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="r" match="r">
+    <xsl:param name="parent-name"/>
+    <xsl:value-of select="text()"/>
+    <xsl:text>_response</xsl:text>
+  </xsl:template>
+
+  <xsl:template name="t" match="t">
+    <xsl:choose>
+      <xsl:when test="count (alts) &gt; 0">
+        <xsl:for-each select="alts/alt">
+          <xsl:choose>
+            <xsl:when test="following-sibling::alt and preceding-sibling::alt">
+              <xsl:text>|</xsl:text>
+              <xsl:value-of select="."/>
+            </xsl:when>
+            <xsl:when test="count (following-sibling::alt) = 0">
+              <xsl:text>|</xsl:text>
+              <xsl:value-of select="."/>
+              <xsl:text>" }</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:text>xsd:token { pattern = "</xsl:text>
+              <xsl:value-of select="."/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="normalize-space(text())"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="pattern-part">
+    <xsl:param name="parent-name"/>
+    <xsl:param name="parent"/>
+    <xsl:choose>
+      <xsl:when test="name()='any'">
+        <xsl:for-each select="*">
+          <xsl:call-template name="pattern-part">
+            <xsl:with-param name="parent-name" select="$parent-name"/>
+            <xsl:with-param name="parent" select="$parent"/>
+          </xsl:call-template>
+        </xsl:for-each>
+        <xsl:text>*</xsl:text>
+      </xsl:when>
+      <xsl:when test="name()='attrib'">
+        <xsl:call-template name="attrib"/>
+      </xsl:when>
+      <xsl:when test="name()='c'">
+        <xsl:call-template name="c"/>
+      </xsl:when>
+      <xsl:when test="name()='e'">
+        <xsl:call-template name="e">
+          <xsl:with-param name="parent-name" select="$parent-name"/>
+          <xsl:with-param name="parent" select="$parent"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="name()='g'">
+        <xsl:text>( </xsl:text>
+        <xsl:for-each select="*">
+          <xsl:choose>
+            <xsl:when test="preceding-sibling::*">
+              <xsl:text>           &amp; </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:call-template name="pattern-part">
+            <xsl:with-param name="parent-name" select="$parent-name"/>
+            <xsl:with-param name="parent" select="$parent"/>
+          </xsl:call-template>
+          <xsl:if test="following-sibling::*">
+            <xsl:call-template name="newline"/>
+          </xsl:if>
+        </xsl:for-each>
+        <xsl:text> )</xsl:text>
+      </xsl:when>
+      <xsl:when test="name()='o'">
+        <xsl:for-each select="*">
+          <xsl:call-template name="pattern-part">
+            <xsl:with-param name="parent-name" select="$parent-name"/>
+            <xsl:with-param name="parent" select="$parent"/>
+          </xsl:call-template>
+        </xsl:for-each>
+        <xsl:text>?</xsl:text>
+      </xsl:when>
+      <xsl:when test="name()='or'">
+        <xsl:text>( </xsl:text>
+        <xsl:for-each select="*">
+          <xsl:choose>
+            <xsl:when test="preceding-sibling::*">
+              <xsl:text>           | </xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+            </xsl:otherwise>
+          </xsl:choose>
+          <xsl:call-template name="pattern-part">
+            <xsl:with-param name="parent-name" select="$parent-name"/>
+            <xsl:with-param name="parent" select="$parent"/>
+          </xsl:call-template>
+          <xsl:if test="following-sibling::*">
+            <xsl:call-template name="newline"/>
+          </xsl:if>
+        </xsl:for-each>
+        <xsl:text> )</xsl:text>
+      </xsl:when>
+      <xsl:when test="name()='r'">
+        <xsl:call-template name="r">
+          <xsl:with-param name="parent-name" select="$parent-name"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="name()='t'">
+      </xsl:when>
+      <xsl:otherwise>
+        ERROR
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="pattern" match="pattern">
+    <xsl:param name="parent-name"/>
+    <xsl:param name="parent"/>
+    <xsl:choose>
+      <xsl:when test="(count (*) = 0) and (string-length (normalize-space (text ())) = 0)">
+        <xsl:text>       ""</xsl:text>
+        <xsl:call-template name="newline"/>
+      </xsl:when>
+      <xsl:when test="(count (t) = 0) and (string-length (normalize-space (text ())) = 0)">
+      </xsl:when>
+      <xsl:when test="count (t) = 0">
+        <xsl:text>       </xsl:text>
+        <xsl:value-of select="normalize-space (text())"/>
+        <xsl:call-template name="newline"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>       </xsl:text>
+        <!-- There should be only one t. -->
+        <xsl:choose>
+          <xsl:when test="(count (*[name()!='t']) = 0)">
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>text # RNC limitation: </xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:for-each select="t">
+          <xsl:call-template name="t"/>
+          <xsl:call-template name="newline"/>
+        </xsl:for-each>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:variable
+      name="empty"
+      select="(count (t) = 0) and (string-length (normalize-space (text ())) = 0)"/>
+    <xsl:for-each select="*[name()!='t']">
+      <xsl:choose>
+        <xsl:when test="preceding-sibling::*">
+          <xsl:text>       &amp; </xsl:text>
+        </xsl:when>
+        <xsl:when test="$empty">
+          <xsl:text>       </xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>       &amp; </xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+      <xsl:call-template name="pattern-part">
+        <xsl:with-param name="parent-name" select="$parent-name"/>
+        <xsl:with-param name="parent" select="$parent"/>
+      </xsl:call-template>
+      <xsl:call-template name="newline"/>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="ele">
+    <xsl:param name="parent-name"/>
+    <xsl:if test="($rnc-comments = 1) and summary">
+      <xsl:text># </xsl:text>
+      <xsl:value-of select="normalize-space(summary)"/>
+      <xsl:text>.</xsl:text>
+      <xsl:call-template name="newline"/>
+    </xsl:if>
+    <xsl:choose>
+      <xsl:when test="type">
+        <xsl:variable name="command-name" select="concat ($parent-name, name)"/>
+        <xsl:value-of select="$command-name"/>
+        <xsl:call-template name="newline"/>
+        <xsl:text> = element </xsl:text>
+        <xsl:value-of select="name"/>
+        <xsl:text>    # type </xsl:text>
+        <xsl:value-of select="type"/>
+        <xsl:call-template name="newline"/>
+        <xsl:text>     {</xsl:text>
+        <xsl:call-template name="newline"/>
+        <xsl:variable name="type" select="type"/>
+        <xsl:variable name="parent" select="/protocol/element[name=$type]"/>
+        <xsl:for-each select="/protocol/element[name=$type]/pattern">
+          <xsl:call-template name="pattern">
+            <xsl:with-param name="parent-name" select="concat ($type, '_')"/>
+            <xsl:with-param name="parent" select="$parent"/>
+          </xsl:call-template>
+        </xsl:for-each>
+        <xsl:text>     }</xsl:text>
+        <xsl:call-template name="newline"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="command-body">
+          <xsl:with-param name="parent-name" select="$parent-name"/>
+          <xsl:with-param name="parent" select="."/>
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="command-body">
+    <xsl:param name="parent-name"/>
+    <xsl:param name="parent" select="."/>
+    <xsl:variable name="command-name" select="concat ($parent-name, name)"/>
+    <xsl:value-of select="$command-name"/>
+    <xsl:call-template name="newline"/>
+    <xsl:text> = element </xsl:text>
+    <xsl:value-of select="name"/>
+    <xsl:call-template name="newline"/>
+    <xsl:text>     {</xsl:text>
+    <xsl:call-template name="newline"/>
+    <xsl:for-each select="pattern">
+      <xsl:call-template name="pattern">
+        <xsl:with-param name="parent-name" select="concat ($command-name, '_')"/>
+        <xsl:with-param name="parent" select="$parent"/>
+      </xsl:call-template>
+    </xsl:for-each>
+    <xsl:text>     }</xsl:text>
+    <xsl:call-template name="newline"/>
+    <xsl:for-each select="ele">
+      <xsl:call-template name="newline"/>
+      <xsl:call-template name="ele">
+        <xsl:with-param name="parent-name" select="concat ($command-name, '_')"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- Responses. -->
+
+  <xsl:template name="response-body">
+    <xsl:variable name="command-name" select="concat (name, '_response')"/>
+    <xsl:value-of select="$command-name"/>
+    <xsl:call-template name="newline"/>
+    <xsl:text> = element </xsl:text>
+    <xsl:value-of select="$command-name"/>
+    <xsl:call-template name="newline"/>
+    <xsl:text>     {</xsl:text>
+    <xsl:call-template name="newline"/>
+    <xsl:for-each select="response/pattern">
+      <xsl:call-template name="pattern">
+        <xsl:with-param name="parent-name" select="concat ($command-name, '_')"/>
+        <xsl:with-param name="parent" select="./.."/>
+      </xsl:call-template>
+    </xsl:for-each>
+    <xsl:text>     }</xsl:text>
+    <xsl:call-template name="newline"/>
+    <xsl:for-each select="response/ele">
+      <xsl:call-template name="newline"/>
+      <xsl:call-template name="ele">
+        <xsl:with-param name="parent-name" select="concat ($command-name, '_')"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
These changes primarily add the opportunity to document elements such as "target".
A more explicit documentation (rather than implicit in the command response documentation)
makes it easier to find details.

Also in the examples, the term "Server" is now used instead of "OSPD" because
OSPD is just one product that implements OSP. 