### PR TITLE
Add <credentials> to <target> element.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -65,10 +65,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
   <element>
     <name>target</name>
-    <summary>A scan target consisting of hosts and a port selection</summary>
+    <summary>A scan target consisting of hosts, a port selection and credentials</summary>
     <pattern>
       <e>hosts</e>
       <e>ports</e>
+      <e>credentials</e>
     </pattern>
     <ele>
       <name>hosts</name>
@@ -77,6 +78,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <ele>
       <name>ports</name>
       <summary>A list of ports that is the same for the given hosts</summary>
+    </ele>
+    <ele>
+      <name>credentials</name>
+      <summary>One or many credentials containing the credential for the given hosts.</summary>
     </ele>
   </element>
 
@@ -663,6 +668,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </attrib>
       <e>scanner_params</e>
       <e>vts</e>
+      <e>targets</e>
     </pattern>
     <ele>
       <name>scanner_params</name>
@@ -734,7 +740,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </response>
     </example>
     <example>
-      <summary>Start a new scan with multi-targets</summary>
+      <summary>Start a new scan with multi-targets. Each one has a different port list and one of them has credentials for authenticated scans.</summary>
       <request>
         <start_scan>
           <scanner_params />
@@ -752,6 +758,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <target>
               <hosts>192.168.1.0/24</hosts>
               <ports>1,2,3,80,443</ports>
+              <credentials>
+                <credential type="up" service="ssh" port="22">
+                  <username>scanuser</username>
+                  <password>mypass</password>
+                </credential>
+                <credential type="up" service="smb">
+                  <username>smbuser</username>
+                  <password>mypass</password>
+                </credential>
+              </credentials>
             </target>
           </targets>
         </start_scan>
@@ -850,7 +866,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <command>START_SCAN</command>
     <summary>target optional element added </summary>
     <description>
-      Added optional element targets to specify different hosts with a different port list. This is take in account only if target and port attributes are not present in start_scan tag.
+      Added optional element targets to specify different hosts with a different port list and credentials. This is take in account only if target and port attributes are not present in start_scan tag.
     </description>
     <version>1.2</version>
   </change>

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -178,6 +178,15 @@ class ScanCollection(object):
 
         return self.scans_table[scan_id]['targets'][0][1]
 
+    def get_credentials(self, scan_id, target):
+        """ Get a scan's credential list. It return dictionary with
+        the corresponding credential for a given target.
+        """
+        if target:
+            for item in self.scans_table[scan_id]['targets']:
+                if target == item[0]:
+                    return item[2]
+
     def get_vts(self, scan_id):
         """ Get a scan's vts list. """
 

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -9,7 +9,6 @@ from defusedxml.common import EntitiesForbidden
 
 from ospd.ospd import OSPDaemon, OSPDError
 
-
 class Result(object):
     def __init__(self, type_, **kwargs):
         self.result_type = type_
@@ -289,3 +288,10 @@ class FullTest(unittest.TestCase):
                                   '</start_scan>'))
         print(ET.tostring(response))
         self.assertEqual(response.get('status'), '200')
+        cred_dict = {'ssh': {'type': 'up', 'password':
+                    'mypass', 'port': '22', 'username':
+                    'scanuser'}, 'smb': {'type': 'up',
+                    'password': 'mypass', 'username': 'smbuser'}}
+        scan_id = response.findtext('id')
+        response = daemon.get_scan_credentials(scan_id, "192.168.0.0/24")
+        self.assertEqual(response, cred_dict)

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -267,3 +267,25 @@ class FullTest(unittest.TestCase):
                                   '</start_scan>'))
         print(ET.tostring(response))
         self.assertEqual(response.get('status'), '200')
+
+    def testMultiTargetWithCredentials(self):
+        daemon = DummyWrapper([])
+        response = secET.fromstring(
+            daemon.handle_command('<start_scan>' +
+                                  '<scanner_params /><vts><vt id="1.2.3.4" />' +
+                                  '</vts>' +
+                                  '<targets><target><hosts>localhosts</hosts>' +
+                                  '<ports>80,443</ports></target><target>' +
+                                  '<hosts>192.168.0.0/24</hosts><ports>22' +
+                                  '</ports><credentials>' +
+                                  '<credential type="up" service="ssh" port="22">' +
+                                  '<username>scanuser</username>' +
+                                  '<password>mypass</password>' +
+                                  '</credential><credential type="up" service="smb">' +
+                                  '<username>smbuser</username>' +
+                                  '<password>mypass</password></credential>' +
+                                  '</credentials>' +
+                                  '</target></targets>' +
+                                  '</start_scan>'))
+        print(ET.tostring(response))
+        self.assertEqual(response.get('status'), '200')


### PR DESCRIPTION
A multi-target start_scan command can  <credential> sub-elements for each <target> element, allowing the authorized scan with different credentials for different targets.