### PR TITLE
 Fix target list in get_scan_response.

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -116,7 +116,8 @@ class ScanCollection(object):
 
         return iter(self.scans_table.keys())
 
-    def create_scan(self, scan_id='', targets='', options=dict(), vts=''):
+    def create_scan(self, scan_id='', targets='', target_str=None,
+                    options=dict(), vts=''):
         """ Creates a new scan with provided scan information. """
 
         if self.data_manager is None:
@@ -125,6 +126,7 @@ class ScanCollection(object):
         scan_info['results'] = list()
         scan_info['progress'] = 0
         scan_info['targets'] = targets
+        scan_info['legacy_target'] = target_str
         scan_info['vts'] = vts
         scan_info['options'] = options
         scan_info['start_time'] = int(time.time())
@@ -162,8 +164,14 @@ class ScanCollection(object):
 
     def get_target(self, scan_id):
         """ Get a scan's target list. """
+        if self.scans_table[scan_id]['legacy_target']:
+            return self.scans_table[scan_id]['legacy_target']
 
-        return self.scans_table[scan_id]['targets']
+        target_list=[]
+        for item in self.scans_table[scan_id]['targets']:
+            target_list.append(item[0])
+        separ = ','
+        return separ.join(target_list)
 
     def get_ports(self, scan_id, target):
         """ Get a scan's ports list. If a target is specified

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -573,7 +573,7 @@ class OSPDaemon(object):
             scan_func = self.start_scan
             scan_params = self.process_scan_params(params)
 
-        scan_id = self.create_scan(scan_id, scan_targets, scan_params, vts)
+        scan_id = self.create_scan(scan_id, scan_targets, target_str, scan_params, vts)
         scan_process = multiprocessing.Process(target=scan_func,
                                                args=(scan_id, scan_targets))
         self.scan_processes[scan_id] = scan_process
@@ -1164,7 +1164,7 @@ class OSPDaemon(object):
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()
 
-    def create_scan(self, scan_id, targets, options, vts):
+    def create_scan(self, scan_id, targets, target_str, options, vts):
         """ Creates a new scan.
 
         @target: Target to scan.
@@ -1172,7 +1172,7 @@ class OSPDaemon(object):
 
         @return: New scan's ID.
         """
-        return self.scan_collection.create_scan(scan_id, targets, options, vts)
+        return self.scan_collection.create_scan(scan_id, targets, target_str, options, vts)
 
     def get_scan_options(self, scan_id):
         """ Gives a scan's list of options. """

--- a/tests/testSSHDaemon.py
+++ b/tests/testSSHDaemon.py
@@ -48,7 +48,7 @@ class TestSSH(unittest.TestCase):
     def testRunCommand(self):
         ospd_ssh.paramiko = fakeparamiko
         daemon = OSPDaemonSimpleSSH('cert', 'key', 'ca')
-        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],],
+        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],], '',
                                     dict(port=5, ssh_timeout=15,
                                          username_password='dummy:pw'), '')
         res = daemon.run_command(scanid, 'host.example.com', 'cat /etc/passwd')
@@ -58,7 +58,7 @@ class TestSSH(unittest.TestCase):
     def testRunCommandLegacyCredential(self):
         ospd_ssh.paramiko = fakeparamiko
         daemon = OSPDaemonSimpleSSH('cert', 'key', 'ca')
-        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],],
+        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],], '',
                                     dict(port=5, ssh_timeout=15,
                                          username='dummy', password='pw'), '')
         res = daemon.run_command(scanid, 'host.example.com', 'cat /etc/passwd')
@@ -78,7 +78,7 @@ class TestSSH(unittest.TestCase):
                              'username': 'smbuser'}}
 
         scanid = daemon.create_scan(None,
-                                    [['host.example.com', '80, 443', cred_dict],],
+                                    [['host.example.com', '80, 443', cred_dict],], '',
                                     dict(port=5, ssh_timeout=15), '')
         res = daemon.run_command(scanid, 'host.example.com', 'cat /etc/passwd')
         self.assertTrue(isinstance(res, list))
@@ -87,7 +87,7 @@ class TestSSH(unittest.TestCase):
     def testRunCommandNoCredential(self):
         ospd_ssh.paramiko = fakeparamiko
         daemon = OSPDaemonSimpleSSH('cert', 'key', 'ca')
-        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],],
+        scanid = daemon.create_scan(None, [['host.example.com', '80, 443', ''],], '',
                                     dict(port=5, ssh_timeout=15), '')
         self.assertRaises(ValueError, daemon.run_command,
                           scanid, 'host.example.com', 'cat /etc/passwd'  )


### PR DESCRIPTION
Send the target list as received for legacy cases or a comma separated list
in case of multi-target scan.
Add unit test.