### PR TITLE
Add support for parallel scans

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -160,6 +160,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <scan_id>Optional UUID value to set as scan ID</scan_id>
               <target>Target hosts to scan in a comma-separated list</target>
               <ports>Ports list to scan as comma-separated list</ports>
+	      <parallel>Optional number of parallel scans to run</parallel>
             </attributes>
             <elements>
               <scanner_params>
@@ -666,6 +667,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Optional UUID value to use as scan ID</summary>
         <type>uuid</type>
       </attrib>
+      <attrib>
+        <name>parallel</name>
+        <summary>Optional number of parallel scan to run </summary>
+        <type>integer</type>
+      </attrib>
       <e>scanner_params</e>
       <e>vts</e>
       <e>targets</e>
@@ -740,9 +746,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </response>
     </example>
     <example>
-      <summary>Start a new scan with multi-targets. Each one has a different port list and one of them has credentials for authenticated scans.</summary>
+      <summary>Start a new scan with multi-targets running simultaneously. Each one has a different port list and one of them has credentials for authenticated scans.</summary>
       <request>
-        <start_scan>
+        <start_scan parallel='10'>
           <scanner_params />
           <vts>
             <vt id='1.3.6.1.4.1.25623.1.0.10662'>
@@ -870,7 +876,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </description>
     <version>1.2</version>
   </change>
-
+  <change>
+    <command>START_SCAN</command>
+    <summary> parallel attribut added </summary>
+    <description>
+      Added optional attribut parallel to specify the number of simultaneous scan to be run.
+    </description>
+    <version>1.2</version>
+  </change>
 
   <change>
     <command>STOP_SCAN</command>

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -349,3 +349,31 @@ class FullTest(unittest.TestCase):
         print(ET.tostring(response))
         scan_res = response.find('scan')
         self.assertEqual(scan_res.get('target'), 'localhosts,192.168.0.0/24')
+
+    def testScanMultiTargetParallelWithError(self):
+        daemon = DummyWrapper([])
+        cmd = secET.fromstring('<start_scan parallel="100a">' +
+                               '<scanner_params />' +
+                               '<targets><target>' +
+                               '<hosts>localhosts</hosts>' +
+                               '<ports>22</ports>' +
+                               '</target></targets>' +
+                               '</start_scan>')
+        time.sleep(1)
+        print(ET.tostring(cmd))
+        self.assertRaises(OSPDError, daemon.handle_start_scan_command, cmd)
+
+    def testScanMultiTargetParallel100(self):
+        daemon = DummyWrapper([])
+        cmd = response = secET.fromstring(
+            daemon.handle_command('<start_scan parallel="100">' +
+                                  '<scanner_params />' +
+                                  '<targets><target>' +
+                                  '<hosts>localhosts</hosts>' +
+                                  '<ports>22</ports>' +
+                                  '</target></targets>' +
+                                  '</start_scan>'))
+        time.sleep(1)
+        print(ET.tostring(cmd))
+        self.assertEqual(response.get('status'), '200')
+


### PR DESCRIPTION
Add 'parallel' attribut to <start_scan> command to specify the maximal
number of simultaneous scans to be run.
Update documentation.
Add unit tests.