### PR TITLE
Add <vtgroup> as subelement of <vts> in <start_scan>

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -682,7 +682,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>vts</name>
-      <summary>Contanins elements that represent Vulnerability Test to be excecute and their parameters</summary>
+      <summary>Contanins elements that represent Vulnerability Test or a collection of Vulnerability Test to be excecute and their parameters</summary>
     </ele>
     <ele>
       <name>targets</name>
@@ -736,6 +736,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             </vt>
             <vt id='1.3.6.1.4.1.25623.1.0.10330'></vt>
             <vt id='1.3.6.1.4.1.25623.1.0.100034'></vt>
+            <vtgroup filter='family=general'/>
+            <vtgroup filter='family=debian'/>
           </vts>
         </start_scan>
       </request>
@@ -755,6 +757,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <vt_param name='XYZ JKL' type='entry'>200</vt_param>
               <vt_param name='ABC' type='checkbox'>yes</vt_param>
             </vt>
+            <vtgroup filter='family=debian'/>
+            <vtgroup filter='family=general'/>
           </vts>
           <targets>
             <target>


### PR DESCRIPTION
Add <vtgroup> as subelement of <vts> in <start_scan>, it allows to select vts collection with a filter.
Fix and add unittest for <vtgroup>.
Update documentation.