### PR TITLE
Add pop_results attribute to <get_scans>.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -182,6 +182,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <attributes>
               <scan_id>ID of a specific scan to get</scan_id>
               <details>Whether to return the full scan report</details>
+              <pop_results>Whether to remove the fetched results</pop_results>
             </attributes>
             <elements></elements>
             <description>List the scans in buffer</description>
@@ -202,6 +203,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <attrib>
         <name>details</name>
         <summary>Whether to get full scan reports</summary>
+        <type>boolean</type>
+      </attrib>
+      <attrib>
+        <name>pop_results</name>
+        <summary>Whether to remove the fetched results</summary>
         <type>boolean</type>
       </attrib>
     </pattern>
@@ -251,7 +257,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <example>
       <summary>Get a scan report summary</summary>
       <request>
-        <get_scans scan_id="f14747d3-a4d7-4e79-99bb-a0a1276cb78c" details="1"/>
+        <get_scans scan_id="f14747d3-a4d7-4e79-99bb-a0a1276cb78c" details="1" pop_results="0"/>
       </request>
       <response>
         <get_scans_response status_text="OK" status="200">

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -107,8 +107,14 @@ class ScanCollection(object):
         if progress == 100:
             self.scans_table[scan_id]['end_time'] = int(time.time())
 
-    def results_iterator(self, scan_id):
-        """ Returns an iterator over scan_id scan's results. """
+    def results_iterator(self, scan_id, pop_res):
+        """ Returns an iterator over scan_id scan's results. If pop_res is True,
+        it removed the fetched results from the list.
+        """
+        if pop_res:
+            result_aux = self.scans_table[scan_id]['results']
+            self.scans_table[scan_id]['results'] = list()
+            return iter(result_aux)
 
         return iter(self.scans_table[scan_id]['results'])
 


### PR DESCRIPTION
This allow to remove the fetched results from the list, to avoid to
get again the already fetched result in subsequent <get_scans> calls.

Update documentation.

Add unit test for pop_results