### PR TITLE
Vt selection

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -196,14 +196,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </element>
 
   <element>
-    <name>vts</name>
+    <name>vt_selection</name>
     <summary>Contanins elements that represent Vulnerability Test or a collection of Vulnerability Test to be excecute and their parameters.</summary>
     <pattern>
-      <o><e>vt</e></o>
-      <any><e>vtgroup</e></any>
+      <o><e>vt_single</e></o>
+      <any><e>vt_group</e></any>
     </pattern>
     <ele>
-      <name>vt</name>
+      <name>vt_single</name>
       <summary>Elements that represent Vulnerability Test.</summary>
       <pattern>
         <attrib>
@@ -212,19 +212,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <type>vt_id</type>
           <required>1</required>
         </attrib>
-        <e>vt_param</e>
+        <e>vt_value</e>
       </pattern>
       <ele>
-        <name>vt_param</name>
+        <name>vt_value</name>
         <summary>Vulnerability Test parameter.</summary>
           <pattern>
             <attrib>
-              <name>name</name>
-              <type>string</type>
-              <required>1</required>
-            </attrib>
-            <attrib>
-              <name>type</name>
+              <name>id</name>
               <type>string</type>
               <required>1</required>
             </attrib>
@@ -233,7 +228,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </ele>
     </ele>
     <ele>
-      <name>vtgroup</name>
+      <name>vt_group</name>
       <summary>Collection of Vulnerability Test</summary>
       <pattern>
         <attrib>
@@ -246,16 +241,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <example>
       <summary>VT with parameters and VT group </summary>
       <e>
-        <vts>
-          <vt id='1.3.6.1.4.1.25623.1.0.10662'>
-            <vt_param name='XYZ JKL' type='entry'>200</vt_param>
-            <vt_param name='ABC' type='checkbox'>yes</vt_param>
-          </vt>
-          <vt id='1.3.6.1.4.1.25623.1.0.10330'></vt>
-          <vt id='1.3.6.1.4.1.25623.1.0.100034'></vt>
-          <vtgroup filter='family=general'/>
-          <vtgroup filter='family=debian'/>
-        </vts>
+        <vt_selection>
+          <vt_single id='1.3.6.1.4.1.25623.1.0.10662'>
+            <vt_value id='XYZ JKL'>200</vt_value>
+            <vt_value id='ABC'>yes</vt_value>
+          </vt_single>
+          <vt_single id='1.3.6.1.4.1.25623.1.0.10330'></vt_single>
+          <vt_single id='1.3.6.1.4.1.25623.1.0.100034'></vt_single>
+          <vt_group filter='family=general'/>
+          <vt_group filter='family=debian'/>
+        </vt_selection>
       </e>
     </example>
   </element>
@@ -854,7 +849,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <type>integer</type>
       </attrib>
       <e>scanner_params</e>
-      <e>vts</e>
+      <e>vt_selection</e>
       <e>targets</e>
     </pattern>
     <ele>
@@ -862,7 +857,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <summary>Contains elements that represent scanner specific parameters</summary>
     </ele>
     <ele>
-      <name>vts</name>
+      <name>vt_selection</name>
       <summary>Contanins elements that represent Vulnerability Test or a collection of Vulnerability Test to be excecute and their parameters</summary>
     </ele>
     <ele>
@@ -912,9 +907,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <scanner_params>
             ...
           </scanner_params>
-          <vts>
+          <vt_selection>
             ....
-          </vts>
+          </vt_selection>
           <targets>
             <target>
               ...

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -252,7 +252,7 @@ class FullTest(unittest.TestCase):
         daemon = DummyWrapper([])
         cmd = secET.fromstring('<start_scan ' +
                                'target="localhost" ports="80, 443">' +
-                               '<scanner_params /><vts /></start_scan>')
+                               '<scanner_params /><vt_selection /></start_scan>')
         print(ET.tostring(cmd))
         self.assertRaises(OSPDError, daemon.handle_start_scan_command, cmd)
 
@@ -260,12 +260,12 @@ class FullTest(unittest.TestCase):
         response = secET.fromstring(
             daemon.handle_command('<start_scan ' +
                                   'target="localhost" ports="80, 443">' +
-                                  '<scanner_params /><vts><vt id="1.2.3.4" />' +
-                                  '</vts></start_scan>'))
+                                  '<scanner_params /><vt_selection><vt_single id="1.2.3.4" />' +
+                                  '</vt_selection></start_scan>'))
         print(ET.tostring(response))
         scan_id = response.findtext('id')
         time.sleep(0.01)
-        self.assertEqual(daemon.get_scan_vts(scan_id), {'1.2.3.4': {}, 'vtgroups': []})
+        self.assertEqual(daemon.get_scan_vts(scan_id), {'1.2.3.4': {}, 'vt_groups': []})
         self.assertNotEqual(daemon.get_scan_vts(scan_id), {'1.2.3.6': {}})
 
         # With out VTS
@@ -281,12 +281,12 @@ class FullTest(unittest.TestCase):
     def testScanWithVTs_and_param(self):
         daemon = DummyWrapper([])
 
-        # Raise because no vt_param name attribute
+        # Raise because no vt_param id attribute
         cmd = secET.fromstring('<start_scan ' +
                                'target="localhost" ports="80, 443">' +
-                               '<scanner_params /><vts><vt id="1234">' +
-                               '<vt_param type="entry">200</vt_param>' +
-                               '</vt></vts></start_scan>')
+                               '<scanner_params /><vt_selection><vt_single id="1234">' +
+                               '<vt_value>200</vt_value>' +
+                               '</vt_single></vt_selection></start_scan>')
         print(ET.tostring(cmd))
         self.assertRaises(OSPDError, daemon.handle_start_scan_command, cmd)
 
@@ -294,21 +294,21 @@ class FullTest(unittest.TestCase):
         response = secET.fromstring(
             daemon.handle_command('<start_scan ' +
                                   'target="localhost" ports="80, 443">' +
-                                  '<scanner_params /><vts><vt id="1234">' +
-                                  '<vt_param name="ABC" type="entry">200' +
-                                  '</vt_param></vt></vts></start_scan>'))
+                                  '<scanner_params /><vt_selection><vt_single id="1234">' +
+                                  '<vt_value id="ABC">200' +
+                                  '</vt_value></vt_single></vt_selection></start_scan>'))
         print(ET.tostring(response))
         scan_id = response.findtext('id')
         time.sleep(0.01)
         self.assertEqual(daemon.get_scan_vts(scan_id),
-                         {'1234': {'ABC': {'type': 'entry', 'value': '200'}}, 'vtgroups': []})
+                         {'1234': {'ABC': '200'}, 'vt_groups': []})
 
 
         # Raise because no vtgroup filter attribute
         cmd = secET.fromstring('<start_scan ' +
                                'target="localhost" ports="80, 443">' +
-                               '<scanner_params /><vts><vtgroup/>' +
-                               '</vts></start_scan>')
+                               '<scanner_params /><vt_selection><vt_group/>' +
+                               '</vt_selection></start_scan>')
         print(ET.tostring(cmd))
         self.assertRaises(OSPDError, daemon.handle_start_scan_command, cmd)
 
@@ -316,14 +316,14 @@ class FullTest(unittest.TestCase):
         response = secET.fromstring(
             daemon.handle_command('<start_scan ' +
                                   'target="localhost" ports="80, 443">' +
-                                  '<scanner_params /><vts>' +
-                                  '<vtgroup filter="a"/>' +
-                                  '</vts></start_scan>'))
+                                  '<scanner_params /><vt_selection>' +
+                                  '<vt_group filter="a"/>' +
+                                  '</vt_selection></start_scan>'))
         print(ET.tostring(response))
         scan_id = response.findtext('id')
         time.sleep(0.01)
         self.assertEqual(daemon.get_scan_vts(scan_id),
-                         {'vtgroups': ['a']})
+                         {'vt_groups': ['a']})
 
 
     def testBillonLaughs(self):


### PR DESCRIPTION
Improve the vt selection element in <start_scan>.
Rename element in start_scan from vts to vt_selection.
Rename vt to vt_single.
Rename vt_param to vt_value.
Remove the type attribute.

Update documentation.

Fix unit tests for vt_selection changes.