### PR TITLE
Fix TOC in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,14 @@ options.
 
 ## Table of Contents
 
-* [OSPD](#ospd)
-  * [Table of Contents](#table-of-contents)
-  * [Installation](#installation)
-    * [Requirements](#requirements)
-    * [Install using pip](#install-using-pip)
-  * [How to write your own OSP Scanner Wrapper](#how-to-write-your-own-osp-scanner-wrapper)
-  * [Support](#support)
-  * [Maintainer](#maintainer)
-  * [Contributing](#contributing)
-  * [License](#license)
+* [Installation](#installation)
+  * [Requirements](#requirements)
+  * [Install using pip](#install-using-pip)
+* [How to write your own OSP Scanner Wrapper](#how-to-write-your-own-osp-scanner-wrapper)
+* [Support](#support)
+* [Maintainer](#maintainer)
+* [Contributing](#contributing)
+* [License](#license)
 
 ## Installation
 


### PR DESCRIPTION
The Table of Contents should not contain it's own title and title of project

https://github.com/greenbone/templates/blob/master/README-template.md#table-of-contents