### PR TITLE
Fix various typos.

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -584,7 +584,7 @@ def ports_str_check_failed(port_str):
 
 def ports_as_list(port_str):
     """
-    Parses a ports string into two list of idividual tcp and udp ports.
+    Parses a ports string into two list of individual tcp and udp ports.
 
     @input string containing a port list
     e.g. T:1,2,3,5-8 U:22,80,600-1024

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -390,7 +390,7 @@ class OSPDaemon(object):
         parameters to be use in a scan and return a dictionary.
 
         @param: XML element with vt subelements. Each vt has an
-                id attribute. Optinal parameters can be included
+                id attribute. Optional parameters can be included
                 as vt child.
                 Example form:
                 <vt_selection>
@@ -700,7 +700,7 @@ class OSPDaemon(object):
                      " {0}:{1}".format(fromaddr[0], fromaddr[1]))
         # NB: Despite the name, ssl.PROTOCOL_SSLv23 selects the highest
         # protocol version that both the client and server support. In modern
-        # Python versions (>= 3.4) it suppports TLS >= 1.0 with SSLv2 and SSLv3
+        # Python versions (>= 3.4) it supports TLS >= 1.0 with SSLv2 and SSLv3
         # being disabled. For Python >=3.5, PROTOCOL_SSLv23 is an alias for
         # PROTOCOL_TLS which should be used once compatibility with Python 3.4
         # is no longer desired.

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -286,7 +286,7 @@ class FullTest(unittest.TestCase):
         scan_id = response.findtext('id')
 
         # Depending on the sistem this test can end with a race condition
-        # because the scanner is already stopped when the <stop_scan> commmand
+        # because the scanner is already stopped when the <stop_scan> command
         # is run.
         time.sleep(3)
         cmd = secET.fromstring('<stop_scan scan_id="%s" />' % scan_id)


### PR DESCRIPTION
Fix various typos found by [codespell](https://github.com/codespell-project/codespell) 1.14

```
codespell . -S ".git"
```