### PR TITLE
Improve vt element regarding dates

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -815,7 +815,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <example>
       <summary>Get information for a single vulnerability test</summary>
       <request>
-        <get_vts id='1.2.3.4.5'/>
+        <get_vts vt_id='1.2.3.4.5'/>
       </request>
       <response>
         <get_vts_response status_text="OK" status="200">
@@ -830,7 +830,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <example>
       <summary>Get information for a vulnerability test with custom data</summary>
       <request>
-        <get_vts id='1.2.3.4.5'/>
+        <get_vts vt_id='1.2.3.4.5'/>
       </request>
       <response>
         <get_vts_response status_text="OK" status="200">
@@ -849,7 +849,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <example>
       <summary>Get information for a vulnerability test with VT parameters data</summary>
       <request>
-        <get_vts id='1.2.3.4.5'/>
+        <get_vts vt_id='1.2.3.4.5'/>
       </request>
       <response>
         <get_vts_response status_text="OK" status="200">

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -775,12 +775,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               <type>vt_id</type>
             </attrib>
             <e>name</e>
+            <e>creation_time</e>
+            <e>modification_time</e>
             <e>vt_params</e>
             <e>vt_refs</e>
             <e>custom</e>
           </pattern>
           <ele>
             <name>name</name>
+          </ele>
+          <ele>
+            <creation_time>creation_time</creation_time>
+          </ele>
+          <ele>
+            <modification_time>modification_time</modification_time>
           </ele>
           <ele>
             <name>vt_params</name>
@@ -813,7 +821,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </response>
     </example>
     <example>
-      <summary>Get information for a single vulnerability test</summary>
+      <summary>Get information for a single vulnerability test with creation and modification times</summary>
       <request>
         <get_vts vt_id='1.2.3.4.5'/>
       </request>
@@ -822,6 +830,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <vts>
             <vt id="1.2.3.4.5">
               <name>Check for presence of vulnerability X</name>
+              <creation_time>1900-01-01</creation_time>
+              <modification_time>2000-01-01</modification_time>
             </vt>
           </vts>
         </get_vts_response>

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -294,7 +294,8 @@ class OSPDaemon(object):
             'scanner_params':
                 {k: v['name'] for k, v in self.scanner_params.items()}}
 
-    def add_vt(self, vt_id, name='', vt_params=None, vt_refs=None, custom=None):
+    def add_vt(self, vt_id, name=None, vt_params=None, vt_refs=None,
+               custom=None):
         """ Add a vulnerability test information.
 
         Returns: The new number of stored VTs.
@@ -311,6 +312,9 @@ class OSPDaemon(object):
 
         if vt_id in self.vts:
             return -1  # The VT was already in the list.
+
+        if name is None:
+            name = ''
 
         self.vts[vt_id] = {'name': name}
         if custom is not None:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1218,14 +1218,14 @@ class OSPDaemon(object):
             vt_xml.append(secET.fromstring(refs_xml_str))
 
         if vt.get('creation_time'):
-            vt_ctime =  self.get_creation_time_vt_as_xml_str(
+            vt_ctime = self.get_creation_time_vt_as_xml_str(
                 vt.get('creation_time'))
             creation_time_xml_str = (
                 '<creation_time>%s</creation_time>' % vt_ctime)
             vt_xml.append(secET.fromstring(creation_time_xml_str))
 
         if vt.get('modification_time'):
-            vt_mtime =  self.get_modification_time_vt_as_xml_str(
+            vt_mtime = self.get_modification_time_vt_as_xml_str(
                 vt.get('modification_time'))
             modification_time_xml_str = (
                 '<modification_time>%s</modification_time>' % vt_mtime)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -294,8 +294,8 @@ class OSPDaemon(object):
             'scanner_params':
                 {k: v['name'] for k, v in self.scanner_params.items()}}
 
-    def add_vt(self, vt_id, name=None, vt_params=None, vt_refs=None,
-               custom=None):
+    def add_vt(self, vt_id, name=None, vt_params=None, vt_refs=None, custom=None
+               vt_creation_time=None, vt_modification_time=None):
         """ Add a vulnerability test information.
 
         Returns: The new number of stored VTs.
@@ -323,7 +323,10 @@ class OSPDaemon(object):
             self.vts[vt_id]["vt_params"] = vt_params
         if vt_refs is not None:
             self.vts[vt_id]["vt_refs"] = vt_refs
-
+        if vt_creationtime is not None:
+            self.vts[vt_id]["creation_time"] = vt_creation_time
+        if vt_modificationtime is not none:
+            self.vts[vt_id]["modification_time"] = vt_modification_time
         return len(self.vts)
 
     def command_exists(self, name):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1153,6 +1153,34 @@ class OSPDaemon(object):
         """
         return ''
 
+    @staticmethod
+    def get_creation_time_vt_as_xml_str(vt_creation_time):
+        """ Create a string representation of the XML object from the
+        vt_creation_time data object.
+        This needs to be implemented by each ospd wrapper, in case
+        vt_creation_time elements for VTs are used.
+
+        The vt_creation_time XML object which is returned will be embedded
+        into a <vt_creation_time></vt_creation_time> element.
+
+        @return: XML object as string for vt creation time data.
+        """
+        return ''
+
+    @staticmethod
+    def get_modification_time_vt_as_xml_str(vt_modification_time):
+        """ Create a string representation of the XML object from the
+        vt_modification_time data object.
+        This needs to be implemented by each ospd wrapper, in case
+        vt_modification_time elements for VTs are used.
+
+        The vt_modification_time XML object which is returned will be embedded
+        into a <vt_modification_time></vt_modification_time> element.
+
+        @return: XML object as string for vt references data.
+        """
+        return ''
+
     def get_vt_xml(self, vt_id):
         """ Gets a single vulnerability test information in XML format.
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -294,8 +294,8 @@ class OSPDaemon(object):
             'scanner_params':
                 {k: v['name'] for k, v in self.scanner_params.items()}}
 
-    def add_vt(self, vt_id, name=None, vt_params=None, vt_refs=None, custom=None
-               vt_creation_time=None, vt_modification_time=None):
+    def add_vt(self, vt_id, name=None, vt_params=None, vt_refs=None,
+               custom=None, vt_creation_time=None, vt_modification_time=None):
         """ Add a vulnerability test information.
 
         Returns: The new number of stored VTs.
@@ -323,9 +323,9 @@ class OSPDaemon(object):
             self.vts[vt_id]["vt_params"] = vt_params
         if vt_refs is not None:
             self.vts[vt_id]["vt_refs"] = vt_refs
-        if vt_creationtime is not None:
+        if vt_creation_time is not None:
             self.vts[vt_id]["creation_time"] = vt_creation_time
-        if vt_modificationtime is not none:
+        if vt_modification_time is not None:
             self.vts[vt_id]["modification_time"] = vt_modification_time
         return len(self.vts)
 
@@ -1200,16 +1200,36 @@ class OSPDaemon(object):
             elem.text = str(value)
 
         if vt.get('custom'):
-            custom_xml_str = '<custom>%s</custom>' % self.get_custom_vt_as_xml_str(vt.get('custom'))
+            custom_xml_str = (
+                '<custom>%s</custom>' % self.get_custom_vt_as_xml_str(
+                    vt.get('custom')))
             vt_xml.append(secET.fromstring(custom_xml_str))
 
         if vt.get('vt_params'):
-            params_xml_str = '<vt_params>%s</vt_params>' % self.get_params_vt_as_xml_str(vt.get('vt_params'))
+            params_xml_str = (
+                '<vt_params>%s</vt_params>' % self.get_params_vt_as_xml_str(
+                    vt.get('vt_params')))
             vt_xml.append(secET.fromstring(params_xml_str))
 
         if vt.get('vt_refs'):
-            refs_xml_str = '<vt_refs>%s</vt_refs>' % self.get_refs_vt_as_xml_str(vt.get('vt_refs'))
+            refs_xml_str = (
+                '<vt_refs>%s</vt_refs>' % self.get_refs_vt_as_xml_str(
+                    vt.get('vt_refs')))
             vt_xml.append(secET.fromstring(refs_xml_str))
+
+        if vt.get('creation_time'):
+            vt_ctime =  self.get_creation_time_vt_as_xml_str(
+                vt.get('creation_time'))
+            creation_time_xml_str = (
+                '<creation_time>%s</creation_time>' % vt_ctime)
+            vt_xml.append(secET.fromstring(creation_time_xml_str))
+
+        if vt.get('modification_time'):
+            vt_mtime =  self.get_modification_time_vt_as_xml_str(
+                vt.get('modification_time'))
+            modification_time_xml_str = (
+                '<modification_time>%s</modification_time>' % vt_mtime)
+            vt_xml.append(secET.fromstring(modification_time_xml_str))
 
         return vt_xml
 


### PR DESCRIPTION
Add two new parameters to add_vt. creation_time and modification_time are now explicit vt's members
in vts dictionary.
Get creation and modification times from vts dict and add them to xml vt element.
Update documentation.