### PR TITLE
Makes the socket a non-blocking socket to allow to run other tasks in the meanwhile

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -376,6 +376,10 @@ class OSPDaemon(object):
         """
         return self.vts_feed_version
 
+    def scheduler(self):
+        """ Should be implemented by subclass in case of need
+        to run tasks periodically. """
+
     def command_exists(self, name):
         """ Checks if a commands exists. """
         return name in self.commands.keys()

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -276,6 +276,7 @@ class OSPDaemon(object):
             self.add_scanner_param(name, param)
         self.vts = dict()
         self.vt_id_pattern = re.compile("[0-9a-zA-Z_\-:.]{1,80}")
+        self.vts_feed_version = None
 
     def set_command_attributes(self, name, attributes):
         """ Sets the xml attributes of a specified command. """
@@ -354,6 +355,26 @@ class OSPDaemon(object):
             self.vts[vt_id]["severities"] = severities
 
         return len(self.vts)
+
+    def set_feed_version(self, feed_version):
+        """ Add into the vts dictionary an entry to identify the
+        feed version.
+
+        Parameters:
+            version (str): Identifies a unique feed version.
+        """
+        if not feed_version:
+            raise OSPDError('A feed_version parameter is required',
+                            'set_feed_version')
+        self.vts_feed_version = feed_version
+
+    def get_feed_version(self):
+        """Return the feed version from the vts dictionary.
+
+        Return:
+            version (str): Identifies a unique feed version.
+        """
+        return self.vts_feed_version
 
     def command_exists(self, name):
         """ Checks if a commands exists. """

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -26,6 +26,7 @@
 from __future__ import absolute_import
 
 import logging
+import select
 import socket
 import ssl
 import multiprocessing
@@ -42,6 +43,8 @@ from ospd.misc import resolve_hostname, valid_uuid
 logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "1.2"
+
+SCHEDULER_CHECK_PERIOD = 5  #in seconds
 
 BASE_SCANNER_PARAMS = {
     'debug_mode': {
@@ -1542,18 +1545,25 @@ class OSPDaemon(object):
         if sock is None:
             return False
 
+        sock.setblocking(False)
+        inputs = [sock]
+        outputs = []
         try:
             while True:
-                if unix_path:
-                    client_stream, _ = sock.accept()
-                    logger.debug("New connection from {0}".format(unix_path))
-                    self.handle_client_stream(client_stream, True)
-                else:
-                    client_stream = self.new_client_stream(sock)
-                    if client_stream is None:
-                        continue
-                    self.handle_client_stream(client_stream, False)
-                close_client_stream(client_stream, unix_path)
+                readable, _, _ = select.select(
+                    inputs, outputs, inputs, SCHEDULER_CHECK_PERIOD)
+                for r_socket in readable:
+                    if unix_path and r_socket is sock:
+                        client_stream, _ = sock.accept()
+                        logger.debug("New connection from {0}".format(unix_path))
+                        self.handle_client_stream(client_stream, True)
+                    else:
+                        client_stream = self.new_client_stream(sock)
+                        if client_stream is None:
+                            continue
+                        self.handle_client_stream(client_stream, False)
+                    close_client_stream(client_stream, unix_path)
+                self.scheduler()
         except KeyboardInterrupt:
             logger.info("Received Ctrl-C shutting-down ...")
         finally:

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -650,3 +650,13 @@ class FullTest(unittest.TestCase):
         daemon.set_scan_target_progress(scan_id, 'localhost1', 75)
         daemon.set_scan_target_progress(scan_id, 'localhost2', 25)
         self.assertEqual(daemon.calculate_progress(scan_id), 50)
+
+    def testSetGetFeedVersion(self):
+        daemon = DummyWrapper([])
+        daemon.set_feed_version('1234')
+        version = daemon.get_feed_version()
+        self.assertEqual('1234', version)
+
+    def testSetGetFeedVersion_Error(self):
+        daemon = DummyWrapper([])
+        self.assertRaises(TypeError, daemon.set_feed_version)


### PR DESCRIPTION
Makes the socket a non-blocking socket. This allows to wait not only for a new connection, but also to
perform other task. When the select timeouts, it calls the scheduler method to run scheduled task, e.g. check for a new feed version.
Add methods to set and get the vts feed version.