### PR TITLE
Improve connection handling

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -777,9 +777,13 @@ class OSPDaemon(object):
         while True:
             try:
                 if is_unix:
-                    data.append(stream.recv(1024))
+                    buf = stream.recv(1024)
                 else:
-                    data.append(stream.read(1024))
+                    buf = stream.read(1024)
+                if len(buf):
+                    data.append(buf)
+                else:
+                    break
                 if len(data) == 0:
                     logger.warning(
                         "Empty client stream (Connection unexpectedly closed)")

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -780,14 +780,9 @@ class OSPDaemon(object):
                     buf = stream.recv(1024)
                 else:
                     buf = stream.read(1024)
-                if len(buf):
-                    data.append(buf)
-                else:
+                if not buf:
                     break
-                if len(data) == 0:
-                    logger.warning(
-                        "Empty client stream (Connection unexpectedly closed)")
-                    return
+                data.append(buf)
             except (AttributeError, ValueError) as message:
                 logger.error(message)
                 return


### PR DESCRIPTION
This commit improves the way connections are handled by the
`handle_client_stream()` method.

Previously, data from the client socket was read until a timeout was
reached after two seconds, i.e. when there was no activity from the open
client socket for two seconds. Beyond reaching this timeout or
encountering an error, there was no way to exit the `while True:` loop
containing the `recv` and `read` calls.

This lead to problems when a client sent data and waited less than two
seconds before closing the connection. Since the timeout was never
reached, the `data.append()` method continued to append `bytes` to the
`data` array indefinitely.

This commit introduces a conditional to check if any additional data was
read and to `break` the loop if not, i.e. all data sent by the client
was consumed.

This has the added benefit of reducing the time the client has to wait
after it is done sending by the two seconds the server previously waited
before starting to process the data.