### PR TITLE
Move OSPDError and improve vts filter.

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -747,6 +747,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
         <summary>Identifier for vulnerability test</summary>
         <type>vt_id</type>
       </attrib>
+      <attrib>
+        <name>filter</name>
+        <summary>Filter to get a sub group of a VT collection</summary>
+        <type>string</type>
+      </attrib>
     </pattern>
     <response>
       <pattern>
@@ -905,6 +910,40 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
               </dependencies>
               <creation_time>2015-02-15 05:47:27 +0100 (Sun, 15 Feb 2015)</creation_time>
               <modification_time>$Date: 2017-07-10 08:34:32 +0200 (Mon, 10 Jul 2017) $</modification_time>
+              <summary>Check the version of App</summary>
+              <affected>App in OS v2</affected>
+              <insight>App is a small but very powerful app.</insight>
+              <solution type="VendorFix">Please Install the Updated Packages.
+              </solution>
+              <detection qod_type="package">Get the installed version with the help of detect NVT and check if the version is vulnerable or not.</detection>
+              <severities>
+                <severity type="cvss_base_v2" origin="CVE-2014-9116">AV:N/AC:L/Au:N/C:N/I:N/A:P</severity>
+              </severities>
+            </vt>
+          </vts>
+        </get_vts_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get information for a filtered collection of vulnerability test</summary>
+      <request>
+        <get_vts filter='modification_time&gt;201903150834;modification_time&lt;201903150835'/>
+      </request>
+      <response>
+        <get_vts_response status_text="OK" status="200">
+          <vts>
+            <vt id="1.2.3.4.5">
+              <name>Check for presence of vulnerability X</name>
+              <refs>
+                <ref id="2014-16494" type="fedora" />
+                <ref id="https://lists.fedoraproject.org/" type="url" />
+                <ref id="CVE-2014-9116" type="cve" />
+              </refs>
+              <dependencies>
+                <dependency vt_id="1.3.6.1.4.1.25623.1.0.50282" />
+              </dependencies>
+              <creation_time>2015-02-15 05:47:27 +0100 (Sun, 15 Feb 2015)</creation_time>
+              <modification_time>$Date: 2019-03-15 08:34:32 +0200 (Mon, 10 Jul 2017) $</modification_time>
               <summary>Check the version of App</summary>
               <affected>App in OS v2</affected>
               <insight>App is a small but very powerful app.</insight>

--- a/ospd/error.py
+++ b/ospd/error.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2014-2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" OSP class for handling errors.
+"""
+
+from ospd.xml import simple_response_str, get_result_xml
+
+class OSPDError(Exception):
+
+    """ This is an exception that will result in an error message to the
+    client """
+
+    def __init__(self, message, command='osp', status=400):
+        super().__init__()
+        self.message = message
+        self.command = command
+        self.status = status
+
+    def as_xml(self):
+        """ Return the error in xml format. """
+        return simple_response_str(self.command, self.status, self.message)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -40,6 +40,8 @@ from ospd import __version__
 from ospd.vtfilter import VtsFilter
 from ospd.misc import ScanCollection, ResultType, target_str_to_list
 from ospd.misc import resolve_hostname, valid_uuid
+from ospd.xml import simple_response_str, get_result_xml
+from ospd.error import OSPDError
 
 logger = logging.getLogger(__name__)
 
@@ -124,59 +126,6 @@ COMMANDS_TABLE = {
     }
 }
 
-
-def get_result_xml(result):
-    """ Formats a scan result to XML format. """
-    result_xml = Element('result')
-    for name, value in [('name', result['name']),
-                        ('type', ResultType.get_str(result['type'])),
-                        ('severity', result['severity']),
-                        ('host', result['host']),
-                        ('test_id', result['test_id']),
-                        ('port', result['port']),
-                        ('qod', result['qod'])]:
-        result_xml.set(name, str(value))
-    result_xml.text = result['value']
-    return result_xml
-
-
-def simple_response_str(command, status, status_text, content=""):
-    """ Creates an OSP response XML string.
-
-    @param: OSP Command to respond to.
-    @param: Status of the response.
-    @param: Status text of the response.
-    @param: Text part of the response XML element.
-
-    @return: String of response in xml format.
-    """
-    response = Element('%s_response' % command)
-    for name, value in [('status', str(status)), ('status_text', status_text)]:
-        response.set(name, str(value))
-    if isinstance(content, list):
-        for elem in content:
-            response.append(elem)
-    elif isinstance(content, Element):
-        response.append(content)
-    else:
-        response.text = content
-    return tostring(response)
-
-
-class OSPDError(Exception):
-
-    """ This is an exception that will result in an error message to the
-    client """
-
-    def __init__(self, message, command='osp', status=400):
-        super(OSPDError, self).__init__()
-        self.message = message
-        self.command = command
-        self.status = status
-
-    def as_xml(self):
-        """ Return the error in xml format. """
-        return simple_response_str(self.command, self.status, self.message)
 
 
 def bind_socket(address, port):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -966,9 +966,14 @@ class OSPDaemon(object):
             text = "Failed to find vulnerability test '{0}'".format(vt_id)
             return simple_response_str('get_vts', 404, text)
 
+        filtered_vts = None
+        if vt_filter:
+            filtered_vts = self.vts_filter.get_filtered_vts_list(
+                self.vts, vt_filter)
+
         responses = []
 
-        vts_xml = self.get_vts_xml(vt_id, vt_filter)
+        vts_xml = self.get_vts_xml(vt_id, filtered_vts)
 
         responses.append(vts_xml)
 
@@ -1376,16 +1381,16 @@ class OSPDaemon(object):
 
         return vt_xml
 
-    def get_vts_xml(self, vt_id=None, vt_filter=None):
+    def get_vts_xml(self, vt_id=None, filtered_vts=None):
         """ Gets collection of vulnerability test information in XML format.
         If vt_id is specified, the collection will contain only this vt, if
         found.
         If no vt_id is specified, the collection will contain all vts or those
-        which match with a given filter.
+        passed in filtered_vts.
 
         Arguments:
-            vt_id (vt_id): ID of the vt to get.
-            vt_filter (string): Filter to use in the vts collection.
+            vt_id (vt_id, optional): ID of the vt to get.
+            filtered_vts (dict, optional): Filtered VTs collection.
 
         Return:
             String of collection of vulnerability test information in
@@ -1396,9 +1401,7 @@ class OSPDaemon(object):
 
         if vt_id:
             vts_xml.append(self.get_vt_xml(vt_id))
-        elif vt_filter:
-            filtered_vts = self.vts_filter.get_filtered_vts_list(
-                self.vts, vt_filter)
+        elif filtered_vts:
             for vt_id in filtered_vts:
                 vts_xml.append(self.get_vt_xml(vt_id))
         else:

--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2014-2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+""" OSP XML utils class.
+"""
+
+from xml.etree.ElementTree import tostring, Element, SubElement
+from ospd.misc import ResultType
+
+def get_result_xml(result):
+    """ Formats a scan result to XML format.
+
+    Arguments:
+        result (dict): Dictionary with a scan result.
+
+    Return:
+        Result as xml element object.
+    """
+    result_xml = Element('result')
+    for name, value in [('name', result['name']),
+                        ('type', ResultType.get_str(result['type'])),
+                        ('severity', result['severity']),
+                        ('host', result['host']),
+                        ('test_id', result['test_id']),
+                        ('port', result['port']),
+                        ('qod', result['qod'])]:
+        result_xml.set(name, str(value))
+    result_xml.text = result['value']
+    return result_xml
+
+
+def simple_response_str(command, status, status_text, content=""):
+    """ Creates an OSP response XML string.
+
+    Arguments:
+        command (str): OSP Command to respond to.
+        status (int): Status of the response.
+        status_text (str): Status text of the response.
+        content (str): Text part of the response XML element.
+
+    Return:
+        String of response in xml format.
+    """
+    response = Element('%s_response' % command)
+    for name, value in [('status', str(status)), ('status_text', status_text)]:
+        response.set(name, str(value))
+    if isinstance(content, list):
+        for elem in content:
+            response.append(elem)
+    elif isinstance(content, Element):
+        response.append(content)
+    else:
+        response.text = content
+    return tostring(response)

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -27,7 +27,9 @@ import xml.etree.ElementTree as ET
 import defusedxml.lxml as secET
 from defusedxml.common import EntitiesForbidden
 
-from ospd.ospd import OSPDaemon, OSPDError
+from ospd.ospd import OSPDaemon
+from ospd.error import OSPDError
+from ospd.xml import simple_response_str, get_result_xml
 
 
 class Result(object):


### PR DESCRIPTION
- Create module ospd.error and ospd.xml
Move OSPDError class from ospd.ospd to its own module.
Move simple_response_str() and get_result_xml() from ospd.ospd to its own module.
This allows to import the modules from other files, avoiding an import loop.
Update tests accordingly.

- Improve the way in which the filter for vts is applied.

- Add error handling to the filter passed to get_vts. 