### PR TITLE
Fix target_to_ipv4_short().

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -359,7 +359,7 @@ def target_to_ipv4_short(target):
         end_value = int(splitted[1])
     except (socket.error, ValueError):
         return None
-    start_value = int(binascii.hexlify(start_packed[3]), 16)
+    start_value = int(binascii.hexlify(bytes(start_packed[3])), 16)
     if end_value < 0 or end_value > 255 or end_value < start_value:
         return None
     end_packed = start_packed[0:3] + struct.pack('B', end_value)

--- a/tests/testTargetConvert.py
+++ b/tests/testTargetConvert.py
@@ -31,5 +31,10 @@ class testTargetLists(unittest.TestCase):
         self.assertEqual(len(addresses), 254)
         for i in range(1, 255):
             self.assertTrue('195.70.81.%d' % i in addresses)
-       
-        
+
+    def testRange(self):
+        addresses = target_str_to_list('195.70.81.1-10')
+        self.assertFalse(addresses is None)
+        self.assertEqual(len(addresses), 10)
+        for i in range(1, 10):
+            self.assertTrue('195.70.81.%d' % i in addresses)


### PR DESCRIPTION
Cast the int to bytes-like to be passed to binascii.hexlify().