### PR TITLE
Resume tasks - Part 1

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -469,6 +469,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <name>progress</name>
             <type>integer</type>
           </attrib>
+          <attrib>
+            <name>status</name>
+            <type>string</type>
+          </attrib>
           <ele>
             <name>results</name>
           </ele>
@@ -483,7 +487,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <response>
         <get_scans_response status_text="OK" status="200">
           <scan id="9750f1f8-07aa-49cc-9c31-2f9e469c8f65" target="192.168.1.252"
-                end_time="1432824234" progress="100" start_time="1432824206">
+                end_time="1432824234" progress="100" status="finished" start_time="1432824206">
              <results>
                <result host="192.168.1.252" severity="2.5" port="443/tcp"
                        test_id="" name="Path disclosure vulnerability"

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -113,6 +113,12 @@ class ScanCollection(object):
             # to parent process.
             self.scans_table[scan_id]['target_progress'] = target_process
 
+    def set_host_finished(self, scan_id, target, host):
+        """ Add the host in a list of finished hosts """
+        finished_hosts = self.scans_table[scan_id]['finished_hosts']
+        finished_hosts[target].extend(host)
+        self.scans_table[scan_id]['finished_hosts'] = finished_hosts
+
     def results_iterator(self, scan_id, pop_res):
         """ Returns an iterator over scan_id scan's results. If pop_res is True,
         it removed the fetched results from the list.
@@ -137,8 +143,11 @@ class ScanCollection(object):
             self.data_manager = multiprocessing.Manager()
         scan_info = self.data_manager.dict()
         scan_info['results'] = list()
+        scan_info['finished_hosts'] = dict(
+            [[target, []] for target, _, _ in targets])
         scan_info['progress'] = 0
-        scan_info['target_progress'] = dict([[elem[0], 0] for elem in targets])
+        scan_info['target_progress'] = dict(
+            [[target, 0] for target, _, _ in targets])
         scan_info['targets'] = targets
         scan_info['legacy_target'] = target_str
         scan_info['vts'] = vts

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -246,7 +246,7 @@ class ScanCollection(object):
     def delete_scan(self, scan_id):
         """ Delete a scan if fully finished. """
 
-        if self.get_progress(scan_id) < 100:
+        if self.get_status(scan_id) == "running":
             return False
         self.scans_table.pop(scan_id)
         if len(self.scans_table) == 0:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -869,6 +869,7 @@ class OSPDaemon(object):
                                                    args=(scan_id, target[0]))
             multiscan_proc.append((scan_process, target[0]))
             scan_process.start()
+            self.set_scan_status(scan_id, "running")
 
         # Wait until all single target were scanned
         while multiscan_proc:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -624,6 +624,11 @@ class OSPDaemon(object):
         scan_id = scan_et.attrib.get('scan_id')
         if scan_id is None or scan_id == '':
             raise OSPDError('No scan_id attribute', 'stop_scan')
+        self.stop_scan(scan_id)
+
+        return simple_response_str('stop_scan', 200, 'OK')
+
+    def stop_scan(self, scan_id):
         scan_process = self.scan_processes.get(scan_id)
         if not scan_process:
             raise OSPDError('Scan not found {0}.'.format(scan_id), 'stop_scan')
@@ -632,17 +637,20 @@ class OSPDaemon(object):
 
         self.set_scan_status(scan_id, "stopped")
         logger.info('%s: Scan stopping %s.', scan_id, scan_process.ident)
-        self.stop_scan(scan_id)
-        scan_process.terminate()
+        self.stop_scan_cleanup(scan_id)
+        try:
+            scan_process.terminate()
+        except AttributeError:
+            logger.debug('%s: The scanner task stopped unexpectedly.', scan_id)
+            self.add_scan_log(scan_id, name='', host='', value='Scan stopped.')
+
         os.killpg(os.getpgid(scan_process.ident), 15)
         scan_process.join()
-        self.set_scan_progress(scan_id, 100)
         self.add_scan_log(scan_id, name='', host='', value='Scan stopped.')
         logger.info('%s: Scan stopped.', scan_id)
-        return simple_response_str('stop_scan', 200, 'OK')
 
     @staticmethod
-    def stop_scan(scan_id):
+    def stop_scan_cleanup(scan_id):
         """ Should be implemented by subclass in case of a clean up before
         terminating is needed. """
 
@@ -815,23 +823,24 @@ class OSPDaemon(object):
 
     def check_pending_target(self, scan_id, multiscan_proc):
         """ Check if a scan process is still alive. In case the process
-        finished, removes the process from the multiscan_process list.
-        In case of the progress is not set from the wrapper for a single
-        target, it will be automatically set if the target scan finished.
+        finished or is stopped, removes the process from the multiscan
+        _process list.
+        Processes dead and with progress < 100% are considered stopped
+        or with failures. Then will try to stop the other runnings (target)
+        scans owned by the same task.
 
         @input scan_id        Scan_id of the whole scan.
         @input multiscan_proc A list with the scan process which
                               may still be alive.
 
-        @return Actualized list with current runnging scan processes."""
-
-        for running_target in multiscan_proc:
-            if not running_target[0].is_alive():
+        @return Actualized list with current runnging scan processes.
+        """
+        for running_target_proc, running_target_id in multiscan_proc:
+            if not running_target_proc.is_alive():
                 target_prog = self.get_scan_target_progress(scan_id)
-                if target_prog[running_target[1]] < 100:
-                    self.set_scan_target_progress(scan_id,
-                                                  running_target[1],
-                                                  100)
+                if target_prog[running_target_id] < 100:
+                    self.stop_scan(scan_id)
+                running_target = (running_target_proc, running_target_id)
                 multiscan_proc.remove(running_target)
         return multiscan_proc
 
@@ -860,8 +869,8 @@ class OSPDaemon(object):
                 self.set_scan_progress(scan_id, progress)
                 time.sleep(1)
 
+            #If the scan status is stopped, does not launch anymore target scans
             if self.get_scan_status(scan_id) == "stopped":
-                self.finish_scan(scan_id)
                 return
 
             logger.info("%s: Host scan started on ports %s.", target[0], target[1])
@@ -879,7 +888,9 @@ class OSPDaemon(object):
                 self.set_scan_progress(scan_id, progress)
             time.sleep(1)
 
-        self.finish_scan(scan_id)
+        # Only set the scan as finished if the scan was not stopped.
+        if self.get_scan_status(scan_id) != "stopped":
+            self.finish_scan(scan_id)
 
     def dry_run_scan(self, scan_id, targets):
         """ Dry runs a scan. """
@@ -1567,10 +1578,10 @@ class OSPDaemon(object):
         scan_process = self.scan_processes[scan_id]
         progress = self.get_scan_progress(scan_id)
         if progress < 100 and not scan_process.is_alive():
-            self.set_scan_progress(scan_id, 100)
+            self.set_scan_status(scan_id, 'stopped')
             self.add_scan_error(scan_id, name="", host="",
                                 value="Scan process failure.")
-            logger.info("%s: Scan terminated.", scan_id)
+            logger.info("%s: Scan stopped with errors.", scan_id)
         elif progress == 100:
             scan_process.join()
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -653,6 +653,7 @@ class OSPDaemon(object):
     def finish_scan(self, scan_id):
         """ Sets a scan as finished. """
         self.set_scan_progress(scan_id, 100)
+        self.set_scan_status(scan_id, 'finished')
         logger.info("%s: Scan finished.", scan_id)
 
     def get_daemon_name(self):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -901,6 +901,10 @@ class OSPDaemon(object):
                             value="{0} exec timeout."
                             .format(self.get_scanner_name()))
 
+    def set_scan_host_finished(self, scan_id, target, host):
+        """ Add the host in a list of finished hosts """
+        self.scan_collection.set_host_finished(scan_id, target, host)
+
     def set_scan_progress(self, scan_id, progress):
         """ Sets scan_id scan's progress which is a number between 0 and 100. """
         self.scan_collection.set_progress(scan_id, progress)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1109,12 +1109,14 @@ class OSPDaemon(object):
 
         target = self.get_scan_target(scan_id)
         progress = self.get_scan_progress(scan_id)
+        status = self.get_scan_status(scan_id)
         start_time = self.get_scan_start_time(scan_id)
         end_time = self.get_scan_end_time(scan_id)
         response = Element('scan')
         for name, value in [('id', scan_id),
                             ('target', target),
                             ('progress', progress),
+                            ('status', status),
                             ('start_time', start_time),
                             ('end_time', end_time)]:
             response.set(name, str(value))

--- a/tests/testScanAndResult.py
+++ b/tests/testScanAndResult.py
@@ -439,7 +439,7 @@ class FullTest(unittest.TestCase):
         self.assertEqual('<modification_time>02-01-1900</modification_time>',
                          ET.tostring(modification_time[0]).decode('utf-8'))
 
-    def testiScanWithError(self):
+    def testScanWithError(self):
         daemon = DummyWrapper([
             Result('error', value='something went wrong'),
         ])
@@ -448,25 +448,23 @@ class FullTest(unittest.TestCase):
             daemon.handle_command('<start_scan target="localhost" ports="80, '
                                   '443"><scanner_params /></start_scan>'))
         scan_id = response.findtext('id')
+
         finished = False
         while not finished:
             response = secET.fromstring(
                 daemon.handle_command(
-                    '<get_scans scan_id="%s" details="0"/>' % scan_id))
+                    '<get_scans scan_id="%s" details="1"/>' % scan_id))
             scans = response.findall('scan')
             self.assertEqual(1, len(scans))
             scan = scans[0]
-            if int(scan.get('progress')) != 100:
+            status = scan.get('status')
+            if not status or status == 'running':
                 self.assertEqual('0', scan.get('end_time'))
                 time.sleep(.010)
             else:
                 finished = True
-        response = secET.fromstring(
-            daemon.handle_command('<get_scans scan_id="%s"/>' % scan_id))
-        response = secET.fromstring(daemon.handle_command('<get_scans />'))
-        response = secET.fromstring(
-            daemon.handle_command(
-                '<get_scans scan_id="%s" details="1"/>' % scan_id))
+        response = secET.fromstring(daemon.handle_command(
+            '<get_scans scan_id="%s" details="1"/>' % scan_id))
         self.assertEqual(response.findtext('scan/results/result'),
                          'something went wrong')
 
@@ -492,6 +490,12 @@ class FullTest(unittest.TestCase):
 
         response = secET.fromstring(
             daemon.handle_command(
+                '<get_scans scan_id="%s" pop_results="1"/>' % scan_id))
+        self.assertEqual(response.findtext('scan/results/result'),
+                         'Some Host Detail')
+
+        response = secET.fromstring(
+            daemon.handle_command(
                 '<get_scans details="0" pop_results="1"/>'))
         self.assertEqual(response.findtext('scan/results/result'),
                          None)
@@ -499,26 +503,21 @@ class FullTest(unittest.TestCase):
         response = secET.fromstring(
             daemon.handle_command(
                 '<get_scans scan_id="%s" pop_results="1"/>' % scan_id))
-        self.assertEqual(response.findtext('scan/results/result'),
-                         'Some Host Detail')
-
-        response = secET.fromstring(
-            daemon.handle_command(
-                '<get_scans scan_id="%s" pop_results="1"/>' % scan_id))
-        self.assertNotEqual(response.findtext('scan/results/result'),
-                            'Some Host Detail')
-        self.assertEqual(response.findtext('scan/results/result'),
-                         None)
 
         while True:
             response = secET.fromstring(
                 daemon.handle_command(
-                    '<get_scans scan_id="%s" details="0"/>' % scan_id))
+                    '<get_scans scan_id="%s" details="1"/>' % scan_id))
             scans = response.findall('scan')
             self.assertEqual(1, len(scans))
             scan = scans[0]
-            if int(scan.get('progress')) == 100:
+            if scan.get('status') == "stopped":
                 break
+
+        scans = response.findall('scan')
+        scan = scans[0]
+        self.assertTrue(response.findtext('scan/results/result') in
+                            ['Scan process failure.', 'Scan stopped.'])
 
         response = secET.fromstring(
             daemon.handle_command('<delete_scan scan_id="%s" />' % scan_id))


### PR DESCRIPTION
- Add new scans status. 
- Return scan status with <get_scans_response>. Update documentation.
- Use this status instead of the scan progress to check a scan. 
- Create a list of finished host for each target of a task (multitarget tasks).
- Improve stop_scan() using the new status.
- Handle killed scans processes and set them as stopped with errors.
- Update unittests.