### PR TITLE
Add support for configuration file.

### DIFF
--- a/ospd/config.py
+++ b/ospd/config.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2019 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+Module to store ospd configuration settings
+"""
+
+import configparser
+import logging
+
+logger = logging.getLogger(__name__)
+
+class Config:
+    def __init__(self, section='main'):
+        self._config = configparser.ConfigParser(default_section=section)
+        self._config = {}
+        self._defaults = dict()
+
+    def load(self, filepath, def_section='main'):
+        path = filepath.expanduser()
+
+        config = configparser.ConfigParser(default_section=def_section)
+
+        with path.open() as f:
+            config.read_file(f)
+
+        self._defaults.update(config.defaults())
+
+        for key, value in config.items(def_section):
+                self._config.setdefault(def_section, dict())[key] = value
+
+    def defaults(self):
+        return self._defaults

--- a/ospd/main.py
+++ b/ospd/main.py
@@ -27,7 +27,7 @@ from typing import Type, Optional
 
 from ospd.misc import go_to_background
 from ospd.ospd import OSPDaemon
-from ospd.parser import create_args_parser, ParserType
+from ospd.parser import create_parser, ParserType
 from ospd.server import TlsServer, UnixSocketServer
 
 COPYRIGHT = """Copyright (C) 2014, 2015, 2018, 2019 Greenbone Networks GmbH
@@ -62,6 +62,7 @@ def init_logging(
     log_file: Optional[str] = None,
     foreground: Optional[bool] = False
 ):
+
     rootlogger = logging.getLogger()
     rootlogger.setLevel(log_level)
 
@@ -107,9 +108,8 @@ def main(
     """ OSPD Main function. """
 
     if not parser:
-        parser = create_args_parser(name)
-
-    args = parser.parse_args()
+        parser = create_parser(name)
+    args = parser.parse_arguments()
 
     init_logging(
         name, args.log_level, log_file=args.log_file, foreground=args.foreground

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -19,6 +19,7 @@
 import argparse
 import logging
 from pathlib import Path
+
 from ospd.config import Config
 
 # Default file locations as used by a OpenVAS default installation

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -18,7 +18,6 @@
 
 import argparse
 import logging
-import configparser
 
 from pathlib import Path
 from ospd.config import Config

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -18,6 +18,10 @@
 
 import argparse
 import logging
+import configparser
+
+from pathlib import Path
+from ospd.config import Config
 
 # Default file locations as used by a OpenVAS default installation
 DEFAULT_KEY_FILE = "/usr/var/lib/gvm/private/CA/serverkey.pem"
@@ -28,16 +32,98 @@ DEFAULT_PORT = 1234
 DEFAULT_ADDRESS = "0.0.0.0"
 DEFAULT_NICENESS = 10
 
+DEFAULT_CONFIG_PATH = '~/.config/ospd.conf'
+DEFAULT_UNIX_SOCKET_PATH = "/tmp/ospd-openvas.sock"
+
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
 
+logger = logging.getLogger(__name__)
 
-def create_args_parser(description: str) -> ParserType:
-    """ Create a command-line arguments parser for OSPD. """
+class CliParser:
 
-    parser = argparse.ArgumentParser(description=description)
+    def __init__(self, description):
+        """ Create a command-line arguments parser for OSPD. """
+        self._name = description
+        parser = argparse.ArgumentParser(description=description)
 
-    def network_port(string):
+        parser.add_argument(
+            '--version', action='store_true', help='Print version then exit.'
+        )
+
+        parser.add_argument(
+            '-s',
+            '--config',
+            nargs='?',
+            default=DEFAULT_CONFIG_PATH,
+            help='Configuration file path (default: %(default)s)',
+        )
+
+        parser.add_argument(
+            '-p',
+            '--port',
+            default=DEFAULT_PORT,
+            type=self.network_port,
+            help='TCP Port to listen on. Default: %(default)s',
+        )
+        parser.add_argument(
+            '-b',
+            '--bind-address',
+            default=DEFAULT_ADDRESS,
+            dest='address',
+            help='Address to listen on. Default: %(default)s',
+        )
+        parser.add_argument(
+            '-u',
+            '--unix-socket',
+            default=DEFAULT_UNIX_SOCKET_PATH,
+            help='Unix file socket to listen on.'
+        )
+        parser.add_argument(
+            '-k',
+            '--key-file',
+            default=DEFAULT_KEY_FILE,
+            help='Server key file. Default: {0}'.format(DEFAULT_KEY_FILE),
+        )
+        parser.add_argument(
+            '-c',
+            '--cert-file',
+            default=DEFAULT_CERT_FILE,
+            help='Server cert file. Default: %(default)s',
+        )
+        parser.add_argument(
+            '--ca-file',
+            help='CA cert file. Default: %(default)s',
+            default=DEFAULT_CA_FILE,
+        )
+        parser.add_argument(
+            '-L',
+            '--log-level',
+            default='WARNING',
+            type=self.log_level,
+            help='Wished level of logging. Default: %(default)s',
+        )
+        parser.add_argument(
+            '-f',
+            '--foreground',
+            action='store_true',
+            help='Run in foreground and logs all messages to console.',
+        )
+        parser.add_argument(
+            '-l',
+            '--log-file',
+            help='Path to the logging file.',
+        )
+        parser.add_argument(
+            '--niceness',
+            default=DEFAULT_NICENESS,
+            type=int,
+            help='Start the scan with the given niceness. Default %(default)s',
+        )
+
+        self.parser = parser
+
+    def network_port(self, string):
         """ Check if provided string is a valid network port. """
 
         value = int(string)
@@ -47,7 +133,7 @@ def create_args_parser(description: str) -> ParserType:
             )
         return value
 
-    def log_level(string):
+    def log_level(self, string):
         """ Check if provided string is a valid log level. """
 
         value = getattr(logging, string.upper(), None)
@@ -57,63 +143,48 @@ def create_args_parser(description: str) -> ParserType:
             )
         return value
 
-    parser.add_argument(
-        '--version', action='store_true', help='Print version then exit.'
-    )
+    def _set_defaults(self, configfilename=None):
+        self._config = self._load_config(configfilename)
+        self.parser.set_defaults(**self._config.defaults())
 
-    parser.add_argument(
-        '-p',
-        '--port',
-        default=DEFAULT_PORT,
-        type=network_port,
-        help='TCP Port to listen on. Default: %(default)s',
-    )
-    parser.add_argument(
-        '-b',
-        '--bind-address',
-        default=DEFAULT_ADDRESS,
-        dest='address',
-        help='Address to listen on. Default: %(default)s',
-    )
-    parser.add_argument(
-        '-u', '--unix-socket', help='Unix file socket to listen on.'
-    )
-    parser.add_argument(
-        '-k',
-        '--key-file',
-        default=DEFAULT_KEY_FILE,
-        help='Server key file. Default: {0}'.format(DEFAULT_KEY_FILE),
-    )
-    parser.add_argument(
-        '-c',
-        '--cert-file',
-        default=DEFAULT_CERT_FILE,
-        help='Server cert file. Default: %(default)s',
-    )
-    parser.add_argument(
-        '--ca-file',
-        help='CA cert file. Default: %(default)s',
-        default=DEFAULT_CA_FILE,
-    )
-    parser.add_argument(
-        '-L',
-        '--log-level',
-        default='WARNING',
-        type=log_level,
-        help='Wished level of logging. Default: %(default)s',
-    )
-    parser.add_argument(
-        '-f',
-        '--foreground',
-        action='store_true',
-        help='Run in foreground and logs all messages to console.',
-    )
-    parser.add_argument('-l', '--log-file', help='Path to the logging file.')
-    parser.add_argument(
-        '--niceness',
-        default=DEFAULT_NICENESS,
-        type=int,
-        help='Start the scan with the given niceness. Default %(default)s',
-    )
+    def _load_config(self, configfile):
+        config = Config()
 
-    return parser
+        if not configfile:
+            return config
+
+        configpath = Path(configfile)
+
+        try:
+            if not configpath.expanduser().resolve().exists():
+                logger.debug('Ignoring non existing config file %s', configfile)
+                return config
+        except FileNotFoundError:
+            # we are on python 3.5 and Path.resolve raised a FileNotFoundError
+            logger.debug('Ignoring non existing config file %s', configfile)
+            return config
+
+        try:
+            config.load(configpath, def_section=self._name)
+            logger.debug('Loaded config %s', configfile)
+        except Exception as e:  # pylint: disable=broad-except
+            raise RuntimeError(
+                'Error while parsing config file {config}. Error was '
+                '{message}'.format(config=configfile, message=e)
+            )
+
+        return config
+
+    def parse_arguments(self, args=None):
+        # Parse args to get the config file path passed as option
+        _args, _ = self.parser.parse_known_args(args)
+
+        # Load the defaults from the config file if it exists.
+        # This override also what it was passed as cmd option.
+        self._set_defaults(_args.config)
+        args, _ = self.parser.parse_known_args(args)
+
+        return args
+
+def create_parser(description):
+    return CliParser(description)

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -18,7 +18,6 @@
 
 import argparse
 import logging
-
 from pathlib import Path
 from ospd.config import Config
 

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -28,7 +28,7 @@ from io import StringIO
 from typing import List
 
 from ospd.parser import (
-    create_args_parser,
+    create_parser,
     Arguments,
     DEFAULT_ADDRESS,
     DEFAULT_PORT,
@@ -39,10 +39,10 @@ from ospd.parser import (
 
 class ArgumentParserTestCase(unittest.TestCase):
     def setUp(self):
-        self.parser = create_args_parser('Wrapper name')
+        self.parser = create_parser('Wrapper name')
 
     def parse_args(self, args: List[str]) -> Arguments:
-        return self.parser.parse_args(args)
+        return self.parser.parse_arguments(args)
 
     @patch('sys.stderr', new_callable=StringIO)
     def test_port_interval(self, _mock_stderr):
@@ -93,3 +93,5 @@ class ArgumentParserTestCase(unittest.TestCase):
         self.assertEqual(args.log_level, logging.WARNING)
         self.assertEqual(args.address, DEFAULT_ADDRESS)
         self.assertEqual(args.port, DEFAULT_PORT)
+
+    

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -94,4 +94,3 @@ class ArgumentParserTestCase(unittest.TestCase):
         self.assertEqual(args.address, DEFAULT_ADDRESS)
         self.assertEqual(args.port, DEFAULT_PORT)
 
-    


### PR DESCRIPTION
All option have a default value. This option are overwritten if this
option is passed as command line argument.
If there is config file, is loaded and the option
listed in it will be set as the valid one, but they will be still
overwritten by the ones passed as cmd option.
This means that cmd options have priority over the other ones.

The config file must have a section with the wrapper name. As ospd
is a base lib for multiple wrappers, each wrapper can have each own
section with its configuration.

The default path for the config file is /home/<user>/.config/ospd.conf

E.g. for ospd-openvas:

`[OSPD - openvas]`
`unix_socket = /tmp/openvas.sock`
`log_level = DEBUG`