### PR TITLE
Add option to set unix socket mode permission.

### DIFF
--- a/ospd/main.py
+++ b/ospd/main.py
@@ -116,7 +116,7 @@ def main(
     )
 
     if args.unix_socket:
-        server = UnixSocketServer(args.unix_socket)
+        server = UnixSocketServer(args.unix_socket, args.socket_mode)
     else:
         server = TlsServer(
             args.address, args.port, args.cert_file, args.key_file, args.ca_file

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -30,9 +30,9 @@ DEFAULT_CA_FILE = "/usr/var/lib/gvm/CA/cacert.pem"
 DEFAULT_PORT = 1234
 DEFAULT_ADDRESS = "0.0.0.0"
 DEFAULT_NICENESS = 10
-
-DEFAULT_CONFIG_PATH = '~/.config/ospd.conf'
-DEFAULT_UNIX_SOCKET_PATH = "/tmp/ospd-openvas.sock"
+DEFAULT_UNIX_SOCKET_MODE = "0o700"
+DEFAULT_CONFIG_PATH = "~/.config/ospd.conf"
+DEFAULT_UNIX_SOCKET_PATH = "/tmp/ospd.sock"
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -78,6 +78,14 @@ class CliParser:
             default=DEFAULT_UNIX_SOCKET_PATH,
             help='Unix file socket to listen on.'
         )
+
+        parser.add_argument(
+            '-m',
+            '--socket-mode',
+            default=DEFAULT_UNIX_SOCKET_MODE,
+            help='Unix file socket mode. Default: %(defaults)s'
+        )
+
         parser.add_argument(
             '-k',
             '--key-file',

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -24,6 +24,7 @@ import select
 import socket
 import ssl
 import time
+import os
 
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -36,7 +37,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_STREAM_TIMEOUT = 2  # two seconds
 DEFAULT_BUFSIZE = 1024
-
 
 class Stream:
     def __init__(self, sock: socket.socket):
@@ -135,9 +135,10 @@ class UnixSocketServer(BaseServer):
     """ Server for accepting connections via a Unix domain socket
     """
 
-    def __init__(self, socket_path: str):
+    def __init__(self, socket_path: str, socket_mode: str):
         super().__init__()
         self.socket_path = Path(socket_path)
+        self.socket_mode = int(socket_mode, 8)
 
     def _cleanup_socket(self):
         if self.socket_path.exists():
@@ -160,6 +161,8 @@ class UnixSocketServer(BaseServer):
             raise OspdError(
                 "Couldn't bind socket on {}".format(self.socket_path)
             )
+
+        os.chmod(str(self.socket_path), self.socket_mode)
 
         logger.info(
             'Unix domain socket server listening on %s', self.socket_path


### PR DESCRIPTION
It must be passed in octal format
E.g. for the config file:

`socket_mode = 0o770`