### PR TITLE
Create pid file to avoid having two daemons.

### DIFF
--- a/ospd/main.py
+++ b/ospd/main.py
@@ -24,6 +24,7 @@ import os
 import sys
 import atexit
 import signal
+
 from functools import partial
 
 from typing import Type, Optional
@@ -131,19 +132,19 @@ def main(
         print_version(daemon)
         sys.exit()
 
-    if not create_pid(args.pid_file):
-        sys.exit()
-
-    daemon.init()
-
     if not args.foreground:
         go_to_background()
+
+    if not create_pid(args.pid_file):
+        sys.exit()
 
     # Set signal handler and cleanup
     atexit.register(remove_pidfile, pidfile=args.pid_file)
     signal.signal(
         signal.SIGTERM, partial(remove_pidfile, args.pid_file)
     )
+
+    daemon.init()
 
     if not daemon.check():
         return 1

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -30,6 +30,7 @@ import multiprocessing
 
 from enum import Enum
 from collections import OrderedDict
+from pathlib import Path
 
 from ospd.network import target_str_to_list
 
@@ -415,14 +416,13 @@ def create_pid(pidfile):
 
     pid = str(os.getpid())
 
-    if os.path.isfile(pidfile):
+    if Path(pidfile).is_file():
         LOGGER.error("There is an already running process.")
         return False
 
     try:
-        f = open(pidfile, 'w')
-        f.write(pid)
-        f.close()
+        with open(pidfile, 'w') as f:
+            f.write(pid)
     except (FileNotFoundError, PermissionError) as e:
         msg = "Failed to create pid file %s. %s" % (os.path.dirname(pidfile), e)
         LOGGER.error(msg)
@@ -432,7 +432,8 @@ def create_pid(pidfile):
 
 def remove_pidfile(pidfile, signum=None, frame=None):
     """ Removes the pidfile before ending the daemon. """
-    if os.path.isfile(pidfile):
+    pidpath = Path(pidfile)
+    if pidpath.is_file():
         LOGGER.debug("Finishing daemon process")
-        os.remove(pidfile)
+        pidpath.unlink()
         sys.exit()

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -408,3 +408,31 @@ def go_to_background():
     except OSError as errmsg:
         LOGGER.error('Fork failed: %s', errmsg)
         sys.exit(1)
+
+def create_pid(pidfile):
+    """ Check if there is an already running daemon and creates the pid file.
+    Otherwise gives an error. """
+
+    pid = str(os.getpid())
+
+    if os.path.isfile(pidfile):
+        LOGGER.error("There is an already running process.")
+        return False
+
+    try:
+        f = open(pidfile, 'w')
+        f.write(pid)
+        f.close()
+    except (FileNotFoundError, PermissionError) as e:
+        msg = "Failed to create pid file %s. %s" % (os.path.dirname(pidfile), e)
+        LOGGER.error(msg)
+        return False
+
+    return True
+
+def remove_pidfile(pidfile, signum=None, frame=None):
+    """ Removes the pidfile before ending the daemon. """
+    if os.path.isfile(pidfile):
+        LOGGER.debug("Finishing daemon process")
+        os.remove(pidfile)
+        sys.exit()

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -33,6 +33,7 @@ DEFAULT_NICENESS = 10
 DEFAULT_UNIX_SOCKET_MODE = "0o700"
 DEFAULT_CONFIG_PATH = "~/.config/ospd.conf"
 DEFAULT_UNIX_SOCKET_PATH = "/tmp/ospd.sock"
+DEFAULT_PID_PATH = "/run/ospd/ospd.pid"
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -77,6 +78,11 @@ class CliParser:
             '--unix-socket',
             default=DEFAULT_UNIX_SOCKET_PATH,
             help='Unix file socket to listen on. Default: %(default)s',
+        )
+        parser.add_argument(
+            '--pid-file',
+            default=DEFAULT_PID_PATH,
+            help='Unix file socket to listen on.'
         )
 
         parser.add_argument(


### PR DESCRIPTION
Adds the --pid-file option in the parser.
Add method to create and remove the pid file.
Set the signal handler and atexit to remove the pid file when the daemon finishes.

How to:
by default, the pid path is /run/ospd/ospd.py. You will have to create the directory and set the right permissions.
```
sudo mkdir /run/ospd`
sudo chown jnicola:jnicola /run/ospd
```

Or you can run ospd-daemon with the option --pid-file and use an existing directory with rw permissions:

```
ospd-openvas --pid-file /tmp/ospd-openvas.pid
```

This is also valid to do it with the config file, adding under the right section the option. E.g.:

```
[OSPD - openvas]
log_level = DEBUG
socket_mode = 0o770
unix_socket = /tmp/openvas.sock
pid_file = /tmp/openvas.sock
```