### PR TITLE
Only the main process can remove the pid file.

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -434,7 +434,7 @@ def remove_pidfile(pidfile, signum=None, frame=None):
     """ Removes the pidfile before ending the daemon. """
     pidpath = Path(pidfile)
     if pidpath.is_file():
-        with open(str(pidpath)) as f:
+        with pidpath.open() as f:
             if int(f.read()) == os.getpid():
                 LOGGER.debug("Finishing daemon process")
                 pidpath.unlink()

--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -434,6 +434,8 @@ def remove_pidfile(pidfile, signum=None, frame=None):
     """ Removes the pidfile before ending the daemon. """
     pidpath = Path(pidfile)
     if pidpath.is_file():
-        LOGGER.debug("Finishing daemon process")
-        pidpath.unlink()
-        sys.exit()
+        with open(str(pidpath)) as f:
+            if int(f.read()) == os.getpid():
+                LOGGER.debug("Finishing daemon process")
+                pidpath.unlink()
+                sys.exit()


### PR DESCRIPTION
This avoid the pid file to be removed when a child process exits.