### PR TITLE
Fix --version option

### DIFF
--- a/ospd/main.py
+++ b/ospd/main.py
@@ -115,6 +115,9 @@ def main(
         parser = create_parser(name)
     args = parser.parse_arguments()
 
+    if args.version:
+        args.foreground = True
+
     init_logging(
         name, args.log_level, log_file=args.log_file, foreground=args.foreground
     )


### PR DESCRIPTION
Force foreground to True if the --version option has been passed.
This avoid to print in the syslog (in case it is the default log facility),
since in this case the stdout is redirected.