### PR TITLE
Add <get_performance>

### DIFF
--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -416,9 +416,66 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <elements></elements>
             <description>List the scans in buffer</description>
           </get_scans>
+          <get_performance>
+            <description>Return system report</description>
+            <elements/>
+            <attributes>
+              <title>Name of report.</title>
+              <start>Time of first data point in report.</start>
+              <end>Time of last data point in report.</end>
+            </attributes>
+          </get_performance>
         </help_response>
       </response>
     </example>
+  </command>
+
+  <command>
+    <name>get_performance</name>
+    <summary>Return performan information from an external program</summary>
+    <pattern>
+      <attrib>
+        <name>start</name>
+        <summary>Interval start</summary>
+        <type>int</type>
+      </attrib>
+      <attrib>
+        <name>end</name>
+        <summary>Interval end</summary>
+        <type>int</type>
+      </attrib>
+      <attrib>
+        <name>titles</name>
+        <summary>Interval title to get</summary>
+        <type>text</type>
+      </attrib>
+    </pattern>
+     <response>
+      <pattern>
+        <attrib>
+          <name>status</name>
+          <type>status</type>
+          <required>1</required>
+        </attrib>
+        <attrib>
+          <name>status_text</name>
+          <type>text</type>
+          <required>1</required>
+        </attrib>
+        text
+      </pattern>
+     </response>
+     <example>
+       <request>
+         <get_performance start='0' titles='mem'/>
+       </request>
+       <response>
+         <help_response status="200" status_text="OK">
+           Some output.
+         </help_response>
+       </response>
+     </example>
+
   </command>
   <command>
     <name>get_scans</name>
@@ -1271,4 +1328,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </description>
     <version>1.1</version>
   </change>
+  <change>
+    <command>GET_PERFORMANCE</command>
+    <summary>Command added</summary>
+    <description>
+      Added new command to get performance from an external program.
+    </description>
+    <version>1.2</version>
+  </change>
+
 </protocol>

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1051,7 +1051,11 @@ class OSPDaemon:
 
         try:
             output = subprocess.check_output(cmd)
-        except subprocess.CalledProcessError as e:
+        except (
+                subprocess.CalledProcessError,
+                PermissionError,
+                FileNotFoundError,
+        ) as e:
             raise OspdCommandError(
                 'Bogus get_performance format. %s' % e,
                 'get_performance'

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -34,6 +34,7 @@ import multiprocessing
 import re
 import time
 import os
+import subprocess
 
 from xml.etree.ElementTree import Element, SubElement
 
@@ -52,6 +53,25 @@ logger = logging.getLogger(__name__)
 PROTOCOL_VERSION = "1.2"
 
 SCHEDULER_CHECK_PERIOD = 5  # in seconds
+
+GVMCG_TITLES = [
+    'cpu-*',
+    'proc',
+    'mem',
+    'swap',
+    'load',
+    'df-*',
+    'disk-sd[a-z][0-9]-rw',
+    'disk-sd[a-z][0-9]-load',
+    'disk-sd[a-z][0-9]-io-load',
+    'interface-eth*-traffic',
+    'interface-eth*-err-rate',
+    'interface-eth*-err',
+    'sensors-*_temperature-*',
+    'sensors-*_fanspeed-*',
+    'sensors-*_voltage-*',
+    'titles',
+]
 
 BASE_SCANNER_PARAMS = {
     'debug_mode': {
@@ -120,6 +140,15 @@ COMMANDS_TABLE = {
     'get_scanner_details': {
         'description': 'Return scanner description and parameters',
         'attributes': None,
+        'elements': None,
+    },
+    'get_performance': {
+        'description': 'Return system report',
+        'attributes': {
+            'start': 'Time of first data point in report.',
+            'end': 'Time of last data point in report.',
+            'title': 'Name of report.',
+        },
         'elements': None,
     },
 }
@@ -978,6 +1007,58 @@ class OSPDaemon:
 
         return simple_response_str('get_vts', 200, 'OK', responses)
 
+    def handle_get_performance(self, scan_et):
+        """ Handles <get_performance> command.
+
+        @return: Response string for <get_performance> command.
+        """
+        start = scan_et.attrib.get('start')
+        end = scan_et.attrib.get('end')
+        titles = scan_et.attrib.get('titles')
+
+        cmd = list()
+        cmd.append('gvmcg')
+        if start:
+            try:
+                int(start)
+            except ValueError:
+                raise OspdCommandError(
+                    'Start argument must be integer.',
+                    'get_performance'
+            )
+            cmd.append(start)
+
+        if end:
+            try:
+                int(end)
+            except ValueError:
+                raise OspdCommandError(
+                    'End argument must be integer.',
+                    'get_performance'
+                )
+            cmd.append(end)
+
+        if titles:
+            combined = "(" + ")|(".join(GVMCG_TITLES) + ")"
+            forbidden = "^[^|&;]+$"
+            if re.match(combined, titles) and re.match(forbidden, titles):
+                cmd.append(titles)
+            else:
+                raise OspdCommandError(
+                    'Arguments not allowed',
+                    'get_performance'
+                )
+
+        try:
+            output = subprocess.check_output(cmd)
+        except subprocess.CalledProcessError as e:
+            raise OspdCommandError(
+                'Bogus get_performance format. %s' % e,
+                'get_performance'
+            )
+
+        return simple_response_str('get_performance', 200, 'OK', str(output))
+
     def handle_help_command(self, scan_et):
         """ Handles <help> command.
 
@@ -1539,6 +1620,8 @@ class OSPDaemon:
             return self.handle_help_command(tree)
         elif tree.tag == "get_scanner_details":
             return self.handle_get_scanner_details()
+        elif tree.tag == "get_performance":
+            return self.handle_get_performance(tree)
         else:
             assert False, "Unhandled command: {0}".format(tree.tag)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1016,8 +1016,7 @@ class OSPDaemon:
         end = scan_et.attrib.get('end')
         titles = scan_et.attrib.get('titles')
 
-        cmd = list()
-        cmd.append('gvmcg')
+        cmd = ['gvmcg']
         if start:
             try:
                 int(start)


### PR DESCRIPTION
Allows to execute a external program/script and get the response.
The program must be named 'gvmcg' and should receive up to 3 arguments
called start, end and titles.

Example with gvm-cli:

```
gvm-cli --protocol OSP socket --socketpath=/run/ospd/openvas.sock --xml "<get_performance start='0' titles='titles'/>"

```