### PR TITLE
Fix tls options. Avoid to listen always in a unix socket.

### DIFF
--- a/ospd/main.py
+++ b/ospd/main.py
@@ -122,7 +122,7 @@ def main(
         name, args.log_level, log_file=args.log_file, foreground=args.foreground
     )
 
-    if args.unix_socket:
+    if args.port == 0:
         server = UnixSocketServer(args.unix_socket, args.socket_mode)
     else:
         server = TlsServer(

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -27,7 +27,7 @@ DEFAULT_KEY_FILE = "/usr/var/lib/gvm/private/CA/serverkey.pem"
 DEFAULT_CERT_FILE = "/usr/var/lib/gvm/CA/servercert.pem"
 DEFAULT_CA_FILE = "/usr/var/lib/gvm/CA/cacert.pem"
 
-DEFAULT_PORT = 1234
+DEFAULT_PORT = 0
 DEFAULT_ADDRESS = "0.0.0.0"
 DEFAULT_NICENESS = 10
 DEFAULT_UNIX_SOCKET_MODE = "0o700"


### PR DESCRIPTION
There was a default unix socket, therefore it will always start a
server which listens in a unix socket.
If a valid port is set, it will listen in a tls socket