### PR TITLE
Fix multi target tasks

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -109,7 +109,7 @@ class ScanCollection(object):
         if progress == 100:
             self.scans_table[scan_id]['end_time'] = int(time.time())
 
-    def set_target_progress(self, scan_id, target, host, progress):
+    def set_host_progress(self, scan_id, target, host, progress):
         """ Sets scan_id scan's progress. """
         if progress > 0 and progress <= 100:
             targets = self.scans_table[scan_id]['target_progress']

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -828,8 +828,6 @@ class OSPDaemon:
                 if _not_finished_clean and _not_stopped:
                     if not self.target_is_finished(scan_id):
                         self.stop_scan(scan_id)
-                    else:
-                        self.set_scan_status(scan_id, ScanStatus.FINISHED)
 
                 running_target = (running_target_proc, running_target_id)
                 multiscan_proc.remove(running_target)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -857,7 +857,7 @@ class OSPDaemon:
             exc_hosts_list = target_str_to_list(exclude_hosts)
             for host in exc_hosts_list:
                 self.set_scan_host_finished(scan_id, target, host)
-                self.set_scan_target_progress(scan_id, target, host, 100)
+                self.set_scan_host_progress(scan_id, target, host, 100)
 
     def start_scan(self, scan_id, targets, parallel=1):
         """ Handle N parallel scans if 'parallel' is greater than 1. """
@@ -941,9 +941,9 @@ class OSPDaemon:
         between 0 and 100. """
         self.scan_collection.set_progress(scan_id, progress)
 
-    def set_scan_target_progress(self, scan_id, target, host, progress):
+    def set_scan_host_progress(self, scan_id, target, host, progress):
         """ Sets host's progress which is part of target. """
-        self.scan_collection.set_target_progress(
+        self.scan_collection.set_host_progress(
             scan_id, target, host, progress
         )
 

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1013,8 +1013,8 @@ class ScanTestCase(unittest.TestCase):
 
         scan_id = response.findtext('id')
 
-        daemon.set_scan_target_progress(scan_id, 'localhost1', 'localhost1', 75)
-        daemon.set_scan_target_progress(scan_id, 'localhost2', 'localhost2', 25)
+        daemon.set_scan_host_progress(scan_id, 'localhost1', 'localhost1', 75)
+        daemon.set_scan_host_progress(scan_id, 'localhost2', 'localhost2', 25)
 
         self.assertEqual(daemon.calculate_progress(scan_id), 50)
 


### PR DESCRIPTION
This will be set when it calculates the progress from the different
host and target.
Now the multi target tasks work again.

Also rename methods