### PR TITLE
Add support to handle multiple requests simultaneously.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add pid file creation to avoid having two daemons. [#126](https://github.com/greenbone/ospd/pull/126) [#128](https://github.com/greenbone/ospd/pull/128)
 - Add OSP <get_performance> command. [#131](https://github.com/greenbone/ospd/pull/131) [#137](https://github.com/greenbone/ospd/pull/137)
 - Add method to check if a target finished cleanly or crashed. [#133](https://github.com/greenbone/ospd/pull/133)
+- Add the --stream-timeout option to configure the socket timeout. [#136](https://github.com/greenbone/ospd/pull/136)
+- Add support to handle multiple requests simultaneously. [#136](https://github.com/greenbone/ospd/pull/136)
 
 ### Changed
 - Improve documentation.

--- a/ospd/main.py
+++ b/ospd/main.py
@@ -123,10 +123,19 @@ def main(
     )
 
     if args.port == 0:
-        server = UnixSocketServer(args.unix_socket, args.socket_mode)
+        server = UnixSocketServer(
+            args.unix_socket,
+            args.socket_mode,
+            args.stream_timeout,
+        )
     else:
         server = TlsServer(
-            args.address, args.port, args.cert_file, args.key_file, args.ca_file
+            args.address,
+            args.port,
+            args.cert_file,
+            args.key_file,
+            args.ca_file,
+            args.stream_timeout,
         )
 
     daemon = daemon_class(**vars(args))

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -44,7 +44,7 @@ from ospd import __version__
 from ospd.errors import OspdCommandError, OspdError
 from ospd.misc import ScanCollection, ResultType, ScanStatus, valid_uuid
 from ospd.network import resolve_hostname, target_str_to_list
-from ospd.server import Server
+from ospd.server import BaseServer
 from ospd.vtfilter import VtsFilter
 from ospd.xml import simple_response_str, get_result_xml
 
@@ -1645,21 +1645,20 @@ class OSPDaemon:
         """ Asserts to False. Should be implemented by subclass. """
         raise NotImplementedError
 
-    def run(self, server: Server):
+    def run(self, server: BaseServer):
         """ Starts the Daemon, handling commands until interrupted.
         """
 
-        server.bind()
+        server.start(self.handle_client_stream)
 
         try:
             while True:
-                server.select(
-                    self.handle_client_stream, timeout=SCHEDULER_CHECK_PERIOD
-                )
+                time.sleep(10)
                 self.scheduler()
         except KeyboardInterrupt:
             logger.info("Received Ctrl-C shutting-down ...")
         finally:
+            logger.info("Shutting-down server ...")
             server.close()
 
     def scheduler(self):

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -34,6 +34,7 @@ DEFAULT_UNIX_SOCKET_MODE = "0o700"
 DEFAULT_CONFIG_PATH = "~/.config/ospd.conf"
 DEFAULT_UNIX_SOCKET_PATH = "/tmp/ospd.sock"
 DEFAULT_PID_PATH = "/run/ospd/ospd.pid"
+DEFAULT_STREAM_TIMEOUT = 10  # ten seconds
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -121,6 +122,13 @@ class CliParser:
             '--foreground',
             action='store_true',
             help='Run in foreground and logs all messages to console.',
+        )
+        parser.add_argument(
+            '-t',
+            '--stream-timeout',
+            default=DEFAULT_STREAM_TIMEOUT,
+            type=int,
+            help='Stream timeout. Default: %(default)s',
         )
         parser.add_argument(
             '-l', '--log-file', help='Path to the logging file.'

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -25,6 +25,8 @@ import socket
 import ssl
 import time
 import os
+import threading
+import socketserver
 
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -83,114 +85,6 @@ class Stream:
 
 StreamCallbackType = Callable[[Stream], None]
 
-
-class Server(ABC):
-    @abstractmethod
-    def bind(self):
-        """ Start listening for incoming connections
-        """
-
-    @abstractmethod
-    def select(
-        self,
-        stream_callback: StreamCallbackType,
-        timeout: Optional[float] = None,
-    ):
-        """ Wait for incoming connections or until timeout is reached
-
-        If a new client connects the stream_callback is called with a Stream
-
-        Arguments:
-            stream_callback (function): Callback function to be called when
-                a stream is ready
-            timeout (float): Timeout in seconds to wait for new streams
-        """
-
-
-class BaseServer(Server):
-    def __init__(self):
-        self.socket = None
-
-    @abstractmethod
-    def _accept(self) -> Stream:
-        pass
-
-    def select(
-        self,
-        stream_callback: StreamCallbackType,
-        timeout: Optional[float] = None,
-    ):
-        inputs = [self.socket]
-
-        readable, _, _ = select.select(inputs, [], inputs, timeout)
-
-        # timeout has fired if readable is empty otherwise a new connection is
-        # available
-        if readable:
-            stream = self._accept()
-            stream_callback(stream)
-
-    def close(self):
-        if self.socket:
-            self.socket.shutdown(socket.SHUT_RDWR)
-            self.socket.close()
-
-
-class UnixSocketServer(BaseServer):
-    """ Server for accepting connections via a Unix domain socket
-    """
-
-    def __init__(self, socket_path: str, socket_mode: str):
-        super().__init__()
-        self.socket_path = Path(socket_path)
-        self.socket_mode = int(socket_mode, 8)
-
-    def _cleanup_socket(self):
-        if self.socket_path.exists():
-            self.socket_path.unlink()
-
-    def _create_parent_dirs(self):
-        # create all parent directories for the socket path
-        parent = self.socket_path.parent
-        parent.mkdir(parents=True, exist_ok=True)
-
-    def bind(self):
-        self._cleanup_socket()
-        self._create_parent_dirs()
-
-        bindsocket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-
-        try:
-            bindsocket.bind(str(self.socket_path))
-        except socket.error:
-            raise OspdError(
-                "Couldn't bind socket on {}".format(self.socket_path)
-            )
-
-        os.chmod(str(self.socket_path), self.socket_mode)
-
-        logger.info(
-            'Unix domain socket server listening on %s', self.socket_path
-        )
-
-        bindsocket.listen(0)
-        bindsocket.setblocking(False)
-
-        self.socket = bindsocket
-
-    def _accept(self) -> Stream:
-        new_socket, _addr = self.socket.accept()
-
-        logger.debug("New connection from %s", self.socket_path)
-
-        return Stream(new_socket)
-
-    def close(self):
-        super().close()
-
-        self._cleanup_socket()
-
-
 def validate_cacert_file(cacert: str):
     """ Check if provided file is a valid CA Certificate """
     try:
@@ -217,6 +111,131 @@ def validate_cacert_file(cacert: str):
         raise OspdError('CA Certificate not active yet')
 
 
+def start_server (stream_callback, newsocket, tls_ctx=None):
+    """ Starts listening and creates a new thread for each new client
+    connection.
+    Arguments:
+            stream_callback (function): Callback function to be called when
+                a stream is ready
+            newsocket (path to socket or socket tuple): The tuple with
+                address and port or the path to the socket for unix domain
+                sockets.
+    Returns the created server object.
+    """
+    class ThreadedRequestHandler(socketserver.BaseRequestHandler):
+        """ Class to handle the request."""
+        def handle(self):
+            cur_thread = threading.current_thread()
+            if tls_ctx:
+                logger.debug(
+                    "New connection from" " %s:%s", newsocket[0], newsocket[1]
+                )
+                socket = tls_ctx.wrap_socket(self.request, server_side=True)
+            else:
+                socket = self.request
+                logger.debug("New connection from %s", newsocket)
+
+            stream = Stream(socket)
+            stream_callback(stream)
+
+    class ThreadedUnixSockServer(
+            socketserver.ThreadingMixIn,
+            socketserver.UnixStreamServer,
+    ):
+        pass
+
+    class ThreadedTlsSockServer(
+            socketserver.ThreadingMixIn,
+            socketserver.TCPServer,
+    ):
+        pass
+
+    if tls_ctx:
+        try:
+            server = ThreadedTlsSockServer(newsocket, ThreadedRequestHandler)
+        except OSError as e:
+            logger.error(
+                "Couldn't bind socket on %s:%s", newsocket[0], newsocket[1]
+            )
+            raise OspdError(
+                "Couldn't bind socket on {}:{}. {}".format(
+                    newsocket[0], str(newsocket[1]), e,
+            ))
+    else:
+        try:
+            server = ThreadedUnixSockServer(
+                str(newsocket), ThreadedRequestHandler
+            )
+        except OSError as e:
+            logger.error("Couldn't bind socket on %s", str(newsocket))
+            raise OspdError(
+                "Couldn't bind socket on {}. {}".format(str(newsocket), e)
+            )
+
+
+    server_thread = threading.Thread(target=server.serve_forever)
+    server_thread.daemon = True
+    server_thread.start()
+
+    return server
+
+
+class BaseServer(ABC):
+    def __init__(self):
+        self.server = None
+
+    @abstractmethod
+    def start(
+        self,
+        stream_callback: StreamCallbackType,
+    ):
+        """ Starts a server with capabilities to handle multiple client
+        connections simultaneously.
+        If a new client connects the stream_callback is called with a Stream
+        Arguments:
+            stream_callback (function): Callback function to be called when
+                a stream is ready
+        """
+
+    def close(self):
+        """ Shutdown the server"""
+        self.server.shutdown()
+        self.server.server_close()
+
+
+class UnixSocketServer(BaseServer):
+    """ Server for accepting connections via a Unix domain socket
+    """
+
+    def __init__(self, socket_path, socket_mode):
+        super().__init__()
+        self.socket_path = Path(socket_path)
+        self.socket_mode = int(socket_mode, 8)
+
+    def _cleanup_socket(self):
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+
+    def _create_parent_dirs(self):
+        # create all parent directories for the socket path
+        parent = self.socket_path.parent
+        parent.mkdir(parents=True, exist_ok=True)
+
+    def start(
+            self,
+            stream_callback: StreamCallbackType,
+    ):
+        self._cleanup_socket()
+        self._create_parent_dirs()
+
+        self.server = start_server(stream_callback, self.socket_path)
+        if self.socket_path.exists():
+            os.chmod(str(self.socket_path), self.socket_mode)
+
+    def close(self):
+        super().close()
+        self._cleanup_socket()
+
 class TlsServer(BaseServer):
     """ Server for accepting TLS encrypted connections via a TCP socket
     """
@@ -230,8 +249,7 @@ class TlsServer(BaseServer):
         ca_file: str,
     ):
         super().__init__()
-        self.address = address
-        self.port = port
+        self.socket = (address, port)
 
         if not Path(cert_file).exists():
             raise OspdError('cert file {} not found'.format(cert_file))
@@ -262,28 +280,12 @@ class TlsServer(BaseServer):
         self.tls_context.load_cert_chain(cert_file, keyfile=key_file)
         self.tls_context.load_verify_locations(ca_file)
 
-    def _accept(self) -> Stream:
-        new_socket, addr = self.socket.accept()
+    def start(self, stream_callback):
+        self.server = start_server(
+            stream_callback,
+            self.socket,
+            tls_ctx=self.tls_context
+        )
 
-        logger.debug("New connection from" " %s:%s", addr[0], addr[1])
-
-        ssl_socket = self.tls_context.wrap_socket(new_socket, server_side=True)
-
-        return Stream(ssl_socket)
-
-    def bind(self):
-        bindsocket = socket.socket()
-        try:
-            bindsocket.bind((self.address, self.port))
-        except socket.error:
-            logger.error(
-                "Couldn't bind socket on %s:%s", self.address, self.port
-            )
-            return None
-
-        logger.info('TLS server listening on %s:%s', self.address, self.port)
-
-        bindsocket.listen(0)
-        bindsocket.setblocking(False)
-
-        self.socket = bindsocket
+    def close(self):
+        super().close()

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -20,7 +20,6 @@ Module for serving and streaming data
 """
 
 import logging
-import select
 import socket
 import ssl
 import time
@@ -111,7 +110,7 @@ def validate_cacert_file(cacert: str):
         raise OspdError('CA Certificate not active yet')
 
 
-def start_server (stream_callback, newsocket, tls_ctx=None):
+def start_server(stream_callback, newsocket, tls_ctx=None):
     """ Starts listening and creates a new thread for each new client
     connection.
     Arguments:
@@ -124,18 +123,18 @@ def start_server (stream_callback, newsocket, tls_ctx=None):
     """
     class ThreadedRequestHandler(socketserver.BaseRequestHandler):
         """ Class to handle the request."""
+
         def handle(self):
-            cur_thread = threading.current_thread()
             if tls_ctx:
                 logger.debug(
                     "New connection from" " %s:%s", newsocket[0], newsocket[1]
                 )
-                socket = tls_ctx.wrap_socket(self.request, server_side=True)
+                req_socket = tls_ctx.wrap_socket(self.request, server_side=True)
             else:
-                socket = self.request
+                req_socket = self.request
                 logger.debug("New connection from %s", newsocket)
 
-            stream = Stream(socket)
+            stream = Stream(req_socket)
             stream_callback(stream)
 
     class ThreadedUnixSockServer(
@@ -286,6 +285,3 @@ class TlsServer(BaseServer):
             self.socket,
             tls_ctx=self.tls_context
         )
-
-    def close(self):
-        super().close()


### PR DESCRIPTION
OSPD can now answer to multiple clients in parallel without a waiting time.
Before, if a client did a request, it should wait until the response to a
first request had been completely sent.

Basically, it replace the bind and select methods from socket module with
a start method which uses instead socketserver and threading modules.