### PR TITLE
Do not add a host detail result with the host status.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use ordered dictionary to maintain the results order. [#119](https://github.com/greenbone/ospd/pull/119)
 - Refactor ospd. [#120](https://github.com/greenbone/ospd/pull/120)
 - Set default unix socket path to /var/run/ospd/ospd.sock and default pid file path to /var/run/ospd.pid. [#140](https://github.com/greenbone/ospd/pull/140)
+- Do not add a host detail result with the host status. [#145](https://github.com/greenbone/ospd/pull/145)
 
 ### Fixed
 - Fix scan progress. [#47](https://github.com/greenbone/ospd/pull/47)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -776,17 +776,11 @@ class OSPDaemon:
         try:
             ret = self.exec_scan(scan_id, target)
             if ret == 0:
-                self.add_scan_host_detail(
-                    scan_id, name='host_status', host=target, value='0'
-                )
+                logger.info("%s: Host scan dead.", target)
             elif ret == 1:
-                self.add_scan_host_detail(
-                    scan_id, name='host_status', host=target, value='1'
-                )
+                logger.info("%s: Host scan alived.", target)
             elif ret == 2:
-                self.add_scan_host_detail(
-                    scan_id, name='host_status', host=target, value='2'
-                )
+                logger.info("%s: Scan error or status unknown.", target)
             else:
                 logger.debug('%s: No host status returned', target)
         except Exception as e:  # pylint: disable=broad-except


### PR DESCRIPTION
For each target a host detail result with the "host_status" was generated, but also an extra host in the report if the host scanned differs from the target.
E.g 1 : target = 127.0.0.1, then scanned host = 127.0.0.1 ----> no extra host in the report.
E.g 2 target = localhost, then scanned host = 127.0.0.1 ----> an extra host in the report with out info. 

The target status will be logged, and no result will be sent to the client.
In future, if a result is necessary, it must be added from the wrapper and not from the base module.