### PR TITLE
[ospd-2.0] Fix set permission on unix socket.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [2.0.1] (unreleased)
+
+### Fixed
+- Fix set permission in unix socket. [#157](https://github.com/greenbone/ospd/pull/157)
+
+[2.0.1]: https://github.com/greenbone/ospd/compare/v2.0.0...ospd-2.0
+
 ## [2.0.0] (2019-10-11)
 
 ### Added

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -202,9 +202,6 @@ class UnixSocketServer(BaseServer):
         self._cleanup_socket()
         self._create_parent_dirs()
 
-        if self.socket_path.exists():
-            os.chmod(str(self.socket_path), self.socket_mode)
-
         try:
             self.stream_callback = stream_callback
             self.server = ThreadedUnixSocketServer(self, str(self.socket_path))
@@ -216,6 +213,9 @@ class UnixSocketServer(BaseServer):
                     str(self.socket_path), e
                 )
             )
+
+        if self.socket_path.exists():
+            self.socket_path.chmod(self.socket_mode)
 
     def close(self):
         super().close()


### PR DESCRIPTION
It was trying to set the permissions on the unix socket before creating it.