### PR TITLE
Set loglevel to debug for some message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [2.0.1] (unreleased)
 
+### Changed
+- Set loglevel to debug for some message. [#159](https://github.com/greenbone/ospd/pull/159)
+
 ### Fixed
 - Fix set permission in unix socket. [#157](https://github.com/greenbone/ospd/pull/157)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -877,7 +877,7 @@ class OSPDaemon:
             if self.get_scan_status(scan_id) == ScanStatus.STOPPED:
                 return
 
-            logger.info(
+            logger.debug(
                 "%s: Host scan started on ports %s.", target[0], target[1]
             )
             scan_process = multiprocessing.Process(
@@ -1165,7 +1165,7 @@ class OSPDaemon:
         for result in self.scan_collection.results_iterator(scan_id, pop_res):
             results.append(get_result_xml(result))
 
-        logger.info('Returning %d results', len(results))
+        logger.debug('Returning %d results', len(results))
         return results
 
     def get_xml_str(self, data):


### PR DESCRIPTION
In case of the port list, it could flood the log file.
For the amount of result, it can be a bit confused, since many results
are "host details" which are not shown in gsa.