### PR TITLE
Add wait_for_children().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add solution method to solution of vt object. [#166](https://github.com/greenbone/ospd/pull/166)
+- Add wait_for_children(). [#167](https://github.com/greenbone/ospd/pull/167)
 
 ### Changes
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)


### PR DESCRIPTION
This release the children faster, in case no client is collecting results.
Make the join() non-blocking.