### PR TITLE
Create data manager and spawn new process to keep the vts dictionary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changes
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)
+- Create data manager and spawn new process to keep the vts dictionary. [#191](https://github.com/greenbone/ospd/pull/191)
 
 ## [2.0.1] (unreleased)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -262,6 +262,13 @@ class OSPDaemon:
         severities=None,
     ):
         """ Add a vulnerability test information.
+
+        IMPORTANT: The VT's Data Manager will store the vts collection.
+        If the collection is considerably big and it will be consultated
+        intensible during a routine, consider to do a deepcopy(), since
+        accessing the shared memory in the data manager is very expencive.
+        At the end of the routine, the temporal copy must be set to None
+        and deleted.
         """
         if self.vts is None:
             self.vts = multiprocessing.Manager().dict()

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1603,7 +1603,10 @@ class OSPDaemon:
         elif vt_id:
             vts_xml.append(self.get_vt_xml(vt_id))
         else:
-            for vt_id in self.vts:
+            # TODO: Because DictProxy for python3.5 doesn't support
+            # iterkeys(), itervalues(), or iteritems() either, the iteration
+            # must be done as follow.
+            for vt_id in iter(self.vts.keys()):
                 vts_xml.append(self.get_vt_xml(vt_id))
 
         return vts_xml

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -263,6 +263,8 @@ class OSPDaemon:
     ):
         """ Add a vulnerability test information.
         """
+        if self.vts is None:
+            self.vts = multiprocessing.Manager().dict()
 
         if not vt_id:
             raise OspdError('Invalid vt_id {}'.format(vt_id))

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -205,7 +205,7 @@ class OSPDaemon:
         for name, param in BASE_SCANNER_PARAMS.items():
             self.add_scanner_param(name, param)
 
-        self.vts = dict()
+        self.vts = None
         self.vt_id_pattern = re.compile("[0-9a-zA-Z_\\-:.]{1,80}")
         self.vts_version = None
 
@@ -1590,6 +1590,9 @@ class OSPDaemon:
         """
 
         vts_xml = Element('vts')
+
+        if not self.vts:
+            return vts_xml
 
         if filtered_vts is not None and len(filtered_vts) == 0:
             return vts_xml

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -266,7 +266,7 @@ class OSPDaemon:
         IMPORTANT: The VT's Data Manager will store the vts collection.
         If the collection is considerably big and it will be consultated
         intensible during a routine, consider to do a deepcopy(), since
-        accessing the shared memory in the data manager is very expencive.
+        accessing the shared memory in the data manager is very expensive.
         At the end of the routine, the temporal copy must be set to None
         and deleted.
         """


### PR DESCRIPTION
A new process is spawn, and it will load the vts in a dictionary.
This process run and keep the collection.
The main process it is lighter now. Therefore, the new fork()'ed scan
processes inherit less memory.