### PR TITLE
Improve get_vts cmd response, sending the vts piece by piece.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)
 - Create data manager and spawn new process to keep the vts dictionary. [#191](https://github.com/greenbone/ospd/pull/191)
 - Update daemon start sequence. Run daemon.check before daemon.init now. [#197](https://github.com/greenbone/ospd/pull/197)
+- Improve get_vts cmd response, sending the vts piece by piece.[#201](https://github.com/greenbone/ospd/pull/201)
 
 ## [2.0.1] (unreleased)
 

--- a/ospd/command/__init__.py
+++ b/ospd/command/__init__.py
@@ -16,4 +16,5 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import ospd.command.command
 from .registry import get_commands

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1142,9 +1142,11 @@ class OSPDaemon:
 
         return vt_xml
 
-    def get_vts_xml(self, vt_id: str = None, filtered_vts: Dict = None):
-        """ Python Generator for VTS.
-        Gets collection of vulnerability test information in XML format.
+    def get_vts_selection_list(
+        self, vt_id: str = None, filtered_vts: Dict = None
+    ) -> List:
+        """
+        Get list of VT's OID.
         If vt_id is specified, the collection will contain only this vt, if
         found.
         If no vt_id is specified or filtered_vts is None (default), the
@@ -1157,8 +1159,7 @@ class OSPDaemon:
             filtered_vts (list, optional): Filtered VTs collection.
 
         Return:
-            String of collection of vulnerability test information in
-            XML format.
+            List of selected VT's OID.
         """
         vts_xml = []
         if not self.vts:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1142,7 +1142,8 @@ class OSPDaemon:
         return vt_xml
 
     def get_vts_xml(self, vt_id: str = None, filtered_vts: Dict = None):
-        """ Gets collection of vulnerability test information in XML format.
+        """ Python Generator for VTS.
+        Gets collection of vulnerability test information in XML format.
         If vt_id is specified, the collection will contain only this vt, if
         found.
         If no vt_id is specified or filtered_vts is None (default), the
@@ -1152,34 +1153,32 @@ class OSPDaemon:
 
         Arguments:
             vt_id (vt_id, optional): ID of the vt to get.
-            filtered_vts (dict, optional): Filtered VTs collection.
+            filtered_vts (list, optional): Filtered VTs collection.
 
         Return:
             String of collection of vulnerability test information in
             XML format.
         """
-
-        vts_xml = Element('vts')
-
+        vts_xml = []
         if not self.vts:
             return vts_xml
 
+        # No match for the filter
         if filtered_vts is not None and len(filtered_vts) == 0:
             return vts_xml
 
         if filtered_vts:
-            for vt_id in filtered_vts:
-                vts_xml.append(self.get_vt_xml(vt_id))
+            vts_list = filtered_vts
         elif vt_id:
-            vts_xml.append(self.get_vt_xml(vt_id))
+            vts_list = [vt_id]
         else:
-            # Because DictProxy for python3.5 doesn't support
+            # TODO: Because DictProxy for python3.5 doesn't support
             # iterkeys(), itervalues(), or iteritems() either, the iteration
             # must be done as follow.
-            for vt_id in iter(self.vts.keys()):
-                vts_xml.append(self.get_vt_xml(vt_id))
+            vts_list = iter(self.vts.keys())
 
-        return vts_xml
+        for vt_id in vts_list:
+            yield self.get_vt_xml(vt_id)
 
     def handle_command(self, command: str, stream) -> str:
         """ Handles an osp command in a string.

--- a/ospd/vtfilter.py
+++ b/ospd/vtfilter.py
@@ -122,7 +122,9 @@ class VtsFilter(object):
         vt_oid_list = list(vts.keys())
 
         for _element, _oper, _filter_val in filters:
-            vts_generator = (vt for vt in vts)
+            # Use iter because python3.5 has no support for
+            # iteration over DictProxy.
+            vts_generator = (vt for vt in iter(vts.keys()))
             for vt_oid in vts_generator:
                 if vt_oid not in vt_oid_list:
                     continue

--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -133,3 +133,82 @@ def elements_as_text(
         text = ''.join([text, ele_txt])
 
     return text
+
+
+class XmlStringHelper:
+    """ Class with methods to help the creation of a xml object in
+    string format.
+    """
+
+    def create_element(self, elem_name: str, end: bool = False) -> bytes:
+        """ Get a name and create the open element of an entity.
+
+        Arguments:
+            elem_name (str): The name of the tag element.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+        if end:
+            ret = "</%s>" % elem_name
+        else:
+            ret = "<%s>" % elem_name
+
+        return ret.encode()
+
+    def create_response(self, command: str, end: bool = False) -> bytes:
+        """ Create or end an xml response.
+
+        Arguments:
+            command (str): The name of the command for the response element.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+        if not command:
+            return
+
+        if end:
+            return ('</%s_response>' % command).encode()
+
+        return (
+            '<%s_response status="200" status_text="OK">' % command
+        ).encode()
+
+    def add_element(
+        self,
+        content: Union[Element, str, list],
+        xml_str: bytes = None,
+        end: bool = False,
+    ) -> bytes:
+        """Create the initial or ending tag for a subelement, or add
+        one or many xml elements
+
+        Arguments:
+            content (Element, str, list): Content to add.
+            xml_str (bytes): Initial string where content to be added to.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+                        It will be added to the xml_str.
+
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+
+        if not xml_str:
+            xml_str = b''
+
+        if content:
+            if isinstance(content, list):
+                for elem in content:
+                    xml_str = xml_str + tostring(elem)
+            elif isinstance(content, Element):
+                xml_str = xml_str + tostring(content)
+            else:
+                if end:
+                    xml_str = xml_str + self.create_element(content, False)
+                else:
+                    xml_str = xml_str + self.create_element(content)
+
+        return xml_str

--- a/tests/command/test_commands.py
+++ b/tests/command/test_commands.py
@@ -24,7 +24,7 @@ from xml.etree import ElementTree as et
 from ospd.command.command import GetPerformance, StartScan, StopScan
 from ospd.errors import OspdCommandError, OspdError
 
-from ..helper import DummyWrapper, assert_called
+from ..helper import DummyWrapper, assert_called, FakeStream
 
 
 class GetPerformanceTestCase(TestCase):
@@ -261,13 +261,15 @@ class StopCommandTestCase(TestCase):
         mock_process.is_alive.return_value = True
         mock_process.pid = "foo"
 
+        fs = FakeStream()
         daemon = DummyWrapper([])
         request = (
             '<start_scan target="localhost" ports="80, 443">'
             '<scanner_params />'
             '</start_scan>'
         )
-        response = et.fromstring(daemon.handle_command(request))
+        daemon.handle_command(request, fs)
+        response = fs.get_response()
 
         assert_called(mock_create_process)
         assert_called(mock_process.start)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -20,6 +20,8 @@ import time
 
 from unittest.mock import Mock
 
+from xml.etree import ElementTree as et
+
 from ospd.ospd import OSPDaemon
 
 
@@ -34,6 +36,17 @@ def assert_called(mock: Mock):
             mock._calls_repr(),  # pylint: disable=protected-access
         )
         raise AssertionError(msg)
+
+
+class FakeStream:
+    def __init__(self):
+        self.response = b''
+
+    def write(self, data):
+        self.response = self.response + data
+
+    def get_response(self):
+        return et.fromstring(self.response)
 
 
 class DummyWrapper(OSPDaemon):


### PR DESCRIPTION
Before the response was a single huge xml element in a string, made before sending
which caused a huge memory consumption. Now the amount of memory used for this cmd
is quite smaller.