### PR TITLE
Fix get_scanner_details().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix stop scan. Wait for the scan process to be stopped before delete it from the process table. [#204](https://github.com/greenbone/ospd/pull/204)
-
+- Fix get_scanner_details(). [#210](https://github.com/greenbone/ospd/pull/210)
 ## [2.0.1] (unreleased)
 
 ### Added

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -21,7 +21,7 @@
 
 from typing import Dict, Union, List, Any
 
-from xml.etree import ElementTree as et
+from xml.etree.ElementTree import SubElement, Element
 
 from ospd.errors import OspdError
 
@@ -29,7 +29,7 @@ from ospd.errors import OspdError
 class OspRequest:
     @staticmethod
     def process_vts_params(
-        scanner_vts: et.Element,
+        scanner_vts: Element,
     ) -> Dict[str, Union[Dict, List]]:
         """ Receive an XML object with the Vulnerability Tests an their
         parameters to be use in a scan and return a dictionary.
@@ -85,7 +85,7 @@ class OspRequest:
         return vt_selection
 
     @staticmethod
-    def process_credentials_elements(cred_tree: et.Element) -> Dict:
+    def process_credentials_elements(cred_tree: Element) -> Dict:
         """ Receive an XML object with the credentials to run
         a scan against a given target.
 
@@ -130,7 +130,7 @@ class OspRequest:
         return credentials
 
     @classmethod
-    def process_targets_element(cls, scanner_target: et.Element) -> List:
+    def process_targets_element(cls, scanner_target: Element) -> List:
         """ Receive an XML object with the target, ports and credentials to run
         a scan against.
 
@@ -227,12 +227,12 @@ class OspRequest:
 
 class OspResponse:
     @staticmethod
-    def create_scanner_params_xml(scanner_params: Dict[str, Any]) -> et.Element:
+    def create_scanner_params_xml(scanner_params: Dict[str, Any]) -> Element:
         """ Returns the OSP Daemon's scanner params in xml format. """
-        scanner_params = et.Element('scanner_params')
+        scanner_params_xml = Element('scanner_params')
 
         for param_id, param in scanner_params.items():
-            param_xml = et.SubElement(scanner_params, 'scanner_param')
+            param_xml = SubElement(scanner_params_xml, 'scanner_param')
 
             for name, value in [('id', param_id), ('type', param['type'])]:
                 param_xml.set(name, value)
@@ -243,7 +243,7 @@ class OspResponse:
                 ('default', param['default']),
                 ('mandatory', param['mandatory']),
             ]:
-                elem = et.SubElement(param_xml, name)
+                elem = SubElement(param_xml, name)
                 elem.text = str(value)
 
-        return scanner_params
+        return scanner_params_xml


### PR DESCRIPTION
Running the test with python3 -m setup.py tests, a test was failing
while running with python3 -m unittest, it doesn't.

The scanner_params variable was overwritten with the xml Element and
passed dictionary was lost.

A second issue was the et.Element type. isinstance() in xml.simple_response_str()
does not recognize et.Element as Element, and therefore the parameter was not added to the final
response. For this reason, Element is used in protocol instead of et.Element.