### PR TITLE
Add methods to remove the vts list from the scan table.

### DIFF
--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -400,7 +400,9 @@ class ScanCollection:
     def release_vts_list(self, scan_id: str) -> None:
         """ Release the memory used for the vts list. """
 
-        self.scans_table[scan_id].pop('vts')
+        scan_data = self.scans_table.get(scan_id)
+        if scan_data and 'vts' in scan_data:
+            del scan_data['vts']
 
     def id_exists(self, scan_id: str) -> bool:
         """ Check whether a scan exists in the table. """

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -397,6 +397,11 @@ class ScanCollection:
 
         return self.scans_table[scan_id]['vts']
 
+    def release_vts_list(self, scan_id: str) -> None:
+        """ Release the memory used for the vts list. """
+
+        self.scans_table[scan_id].pop('vts')
+
     def id_exists(self, scan_id: str) -> bool:
         """ Check whether a scan exists in the table. """
 


### PR DESCRIPTION
This allows to release memory in case the vts are not used anymore
during the scan.