### PR TITLE
Use defined constant for the scheduler interval

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -55,7 +55,7 @@ logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = "1.2"
 
-SCHEDULER_CHECK_PERIOD = 5  # in seconds
+SCHEDULER_CHECK_PERIOD = 10  # in seconds
 
 BASE_SCANNER_PARAMS = {
     'debug_mode': {
@@ -1109,7 +1109,7 @@ class OSPDaemon:
 
         try:
             while True:
-                time.sleep(10)
+                time.sleep(SCHEDULER_CHECK_PERIOD)
                 self.scheduler()
                 self.clean_forgotten_scans()
                 self.wait_for_children()


### PR DESCRIPTION
SCHEDULER_CHECK_PERIODS was defined but never used. Adjust it to 10
seconds and use it now.