### PR TITLE
Send the VTs by chunk as response for get_vts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Set default unix socket path to /var/run/ospd/ospd.sock and default pid file path to /var/run/ospd.pid. [#140](https://github.com/greenbone/ospd/pull/140)
 - Do not add a host detail result with the host status. [#145](https://github.com/greenbone/ospd/pull/145)
 - Do not log the received command. [#151](https://github.com/greenbone/ospd/pull/151)
+- Send the VTs by chunk as response for get_vts. [#215](https://github.com/greenbone/ospd/pull/215)
 
 ### Fixed
 - Fix scan progress. [#47](https://github.com/greenbone/ospd/pull/47)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1060,7 +1060,8 @@ class OSPDaemon:
         yield xml_helper.create_element('vts')
 
         for vt in self.get_vt_iterator():
-            if list(vt.keys())[0] not in filtered_vts:
+            vt_id, _ = vt
+            if vt_id not in filtered_vts:
                 continue
             yield xml_helper.add_element(self.get_vt_xml(vt))
 
@@ -1477,7 +1478,7 @@ class OSPDaemon:
 
     def get_vt_iterator(self):
         for vt_id, val in self.vts.items():
-            yield {vt_id: val}
+            yield (vt_id, val)
 
     def get_vt_xml(self, single_vt):
         """ Gets a single vulnerability test information in XML format.
@@ -1487,8 +1488,7 @@ class OSPDaemon:
         if not single_vt:
             return Element('vt')
 
-        vt_id = list(single_vt.keys())[0]
-        vt = single_vt.get(vt_id)
+        vt_id, vt = single_vt
         name = vt.get('name')
         vt_xml = Element('vt')
         vt_xml.set('id', vt_id)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1059,8 +1059,8 @@ class OSPDaemon:
         yield xml_helper.create_response('get_vts')
         yield xml_helper.create_element('vts')
 
-        for vt in self.get_vt_generator():
-            if vt.get('id') not in filtered_vts:
+        for vt in self.get_vt_iterator():
+            if list(vt.keys())[0] not in filtered_vts:
                 continue
             yield xml_helper.add_element(self.get_vt_xml(vt))
 
@@ -1475,18 +1475,20 @@ class OSPDaemon:
         """
         return ''
 
-    def get_vt_generator(self, vt_id):
-        pass
+    def get_vt_iterator(self):
+        for vt_id, val in self.vts.items():
+            yield {vt_id: val}
 
-    def get_vt_xml(self, vt):
+    def get_vt_xml(self, single_vt):
         """ Gets a single vulnerability test information in XML format.
 
         @return: String of single vulnerability test information in XML format.
         """
-        if not vt:
+        if not single_vt:
             return Element('vt')
 
-        vt_id = vt.get('id')
+        vt_id = list(single_vt.keys())[0]
+        vt = single_vt.get(vt_id)
         name = vt.get('name')
         vt_xml = Element('vt')
         vt_xml.set('id', vt_id)

--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -72,3 +72,91 @@ def simple_response_str(command, status, status_text, content=""):
     else:
         response.text = content
     return tostring(response)
+
+
+class XmlStringHelper:
+    """ Class with methods to help the creation of a xml object in
+    string format.
+    """
+
+    def create_element(self, elem_name: str, end: bool = False) -> bytes:
+        """ Get a name and create the open element of an entity.
+        Arguments:
+            elem_name (str): The name of the tag element.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+        if end:
+            ret = "</%s>" % elem_name
+        else:
+            ret = "<%s>" % elem_name
+
+        return ret.encode()
+
+    def create_response(self, command: str, end: bool = False) -> bytes:
+        """ Create or end an xml response.
+        Arguments:
+            command (str): The name of the command for the response element.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+        if not command:
+            return
+
+        if end:
+            return ('</%s_response>' % command).encode()
+
+        return (
+            '<%s_response status="200" status_text="OK">' % command
+        ).encode()
+
+    def add_element(self, content, xml_str=None, end=False,) -> bytes:
+        """Create the initial or ending tag for a subelement, or add
+        one or many xml elements
+        Arguments:
+            content (Element, str, list): Content to add.
+            xml_str (bytes): Initial string where content to be added to.
+            end (bool): Create a initial tag if False, otherwise the end tag.
+                        It will be added to the xml_str.
+        Return:
+            Encoded string representing a part of an xml element.
+        """
+
+        if not xml_str:
+            xml_str = b''
+
+        if content:
+            if isinstance(content, list):
+                for elem in content:
+                    xml_str = xml_str + tostring(elem)
+            elif isinstance(content, Element):
+                xml_str = xml_str + tostring(content)
+            else:
+                if end:
+                    xml_str = xml_str + self.create_element(content, False)
+                else:
+                    xml_str = xml_str + self.create_element(content)
+
+        return xml_str
+
+    def add_attr(self, tag: bytes, attribute: str, value: str = None) -> bytes:
+        """ Add an attribute to the beginnig tag of an xml element.
+        Arguments:
+            tag (bytes): Tag to add the attrubute to.
+            attribute (str): Attribute name
+            value (str): Attribute value
+        Return:
+            Tag in encoded string format with the given attribute
+        """
+        if not tag:
+            return None
+
+        if not attribute:
+            return tag
+
+        if not value:
+            value = ''
+
+        return tag[:-1] + (" %s=\'%s\'>" % (attribute, value)).encode()


### PR DESCRIPTION
Since the VTs are not in the ospd cache anymore, they are get from a a generator to be sent to the client.

The generator must be implemented in the wrapper and should return a single vt dictionary to be converted in xml format and to be sent to the client.
Therefore, get_vt_xml() does not receive a vt id anymore, but the vt dictionary.