### PR TITLE
Add lock-file-dir configuration option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add clean_forgotten_scans(). [#171](https://github.com/greenbone/ospd/pull/171)
 - Extend OSP with finished_hosts to improve resume task.  [#177](https://github.com/greenbone/ospd/pull/177)
+- Add lock-file-dir configuration option. [#217](https://github.com/greenbone/ospd/pull/217)
 
 ### Changed
 - Set loglevel to debug for some message. [#159](https://github.com/greenbone/ospd/pull/159)

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -34,6 +34,7 @@ DEFAULT_UNIX_SOCKET_MODE = "0o700"
 DEFAULT_CONFIG_PATH = "~/.config/ospd.conf"
 DEFAULT_UNIX_SOCKET_PATH = "/var/run/ospd/ospd.sock"
 DEFAULT_PID_PATH = "/var/run/ospd.pid"
+DEFAULT_LOCKFILE_DIR_PATH = "/var/run/ospd"
 DEFAULT_STREAM_TIMEOUT = 10  # ten seconds
 DEFAULT_SCANINFO_STORE_TIME = 0  # in hours
 
@@ -84,16 +85,19 @@ class CliParser:
         parser.add_argument(
             '--pid-file',
             default=DEFAULT_PID_PATH,
-            help='Unix file socket to listen on.',
+            help='Unix file socket to listen on. Default: %(default)s.',
         )
-
+        parser.add_argument(
+            '--lock-file-dir',
+            default=DEFAULT_LOCKFILE_DIR_PATH,
+            help='Directory where lock files are placed. Default: %(default)s',
+        )
         parser.add_argument(
             '-m',
             '--socket-mode',
             default=DEFAULT_UNIX_SOCKET_MODE,
             help='Unix file socket mode. Default: %(default)s',
         )
-
         parser.add_argument(
             '-k',
             '--key-file',

--- a/tests/test_argument_parser.py
+++ b/tests/test_argument_parser.py
@@ -35,6 +35,10 @@ from ospd.parser import (
     DEFAULT_KEY_FILE,
     DEFAULT_NICENESS,
     DEFAULT_SCANINFO_STORE_TIME,
+    DEFAULT_CONFIG_PATH,
+    DEFAULT_UNIX_SOCKET_PATH,
+    DEFAULT_PID_PATH,
+    DEFAULT_LOCKFILE_DIR_PATH,
 )
 
 
@@ -94,4 +98,8 @@ class ArgumentParserTestCase(unittest.TestCase):
         self.assertEqual(args.log_level, logging.WARNING)
         self.assertEqual(args.address, DEFAULT_ADDRESS)
         self.assertEqual(args.port, DEFAULT_PORT)
-        self.assertEqual(args.port, DEFAULT_SCANINFO_STORE_TIME)
+        self.assertEqual(args.scaninfo_store_time, DEFAULT_SCANINFO_STORE_TIME)
+        self.assertEqual(args.config, DEFAULT_CONFIG_PATH)
+        self.assertEqual(args.unix_socket, DEFAULT_UNIX_SOCKET_PATH)
+        self.assertEqual(args.pid_file, DEFAULT_PID_PATH)
+        self.assertEqual(args.lock_file_dir, DEFAULT_LOCKFILE_DIR_PATH)


### PR DESCRIPTION
By default  the directory is /var/run/ospd. In this directory can be placed lock files in case of need.
E.g.: during feed update to block other processes.