### PR TITLE
Extend get_vt_iterator() with a vt selection parameter.

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -333,10 +333,8 @@ class GetVts(BaseCommand):
 
         yield begin_vts_tag
 
-        for vt in self._daemon.get_vt_iterator():
+        for vt in self._daemon.get_vt_iterator(vts_selection):
             vt_id, _ = vt
-            if vt_id not in vts_selection:
-                continue
             yield xml_helper.add_element(self._daemon.get_vt_xml(vt))
 
         yield xml_helper.create_element('vts', end=True)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -955,7 +955,9 @@ class OSPDaemon:
         """
         return ''
 
-    def get_vt_iterator(self) -> Iterator[Tuple[str, Dict]]:
+    def get_vt_iterator(
+        self, vt_selection: List[str] = None
+    ) -> Iterator[Tuple[str, Dict]]:
         """ Return iterator object for getting elements
         from the VTs dictionary. """
         return self.vts.items()


### PR DESCRIPTION
It is not implemented by default, therefore the whole collection
will be return if this method is not implemented in the wrapper side.

