### PR TITLE
Encode the xml string in utf-8 before sending it

### DIFF
--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -85,7 +85,7 @@ def simple_response_str(
     else:
         response.text = content
 
-    return tostring(response)
+    return tostring(response, encoding='utf-8')
 
 
 def get_elements_from_dict(data: Dict[str, Any]) -> List[Element]:
@@ -158,7 +158,7 @@ class XmlStringHelper:
         else:
             ret = "<%s>" % elem_name
 
-        return ret.encode()
+        return ret.encode('utf-8')
 
     def create_response(self, command: str, end: bool = False) -> bytes:
         """ Create or end an xml response.
@@ -174,11 +174,11 @@ class XmlStringHelper:
             return
 
         if end:
-            return ('</%s_response>' % command).encode()
+            return ('</%s_response>' % command).encode('utf-8')
 
-        return (
-            '<%s_response status="200" status_text="OK">' % command
-        ).encode()
+        return ('<%s_response status="200" status_text="OK">' % command).encode(
+            'utf-8'
+        )
 
     def add_element(
         self,
@@ -205,9 +205,9 @@ class XmlStringHelper:
         if content:
             if isinstance(content, list):
                 for elem in content:
-                    xml_str = xml_str + tostring(elem)
+                    xml_str = xml_str + tostring(elem, encoding='utf-8')
             elif isinstance(content, Element):
-                xml_str = xml_str + tostring(content)
+                xml_str = xml_str + tostring(content, encoding='utf-8')
             else:
                 if end:
                     xml_str = xml_str + self.create_element(content, False)
@@ -234,4 +234,4 @@ class XmlStringHelper:
         if not value:
             value = ''
 
-        return tag[:-1] + (" %s=\'%s\'>" % (attribute, value)).encode()
+        return tag[:-1] + (" %s=\'%s\'>" % (attribute, value)).encode('utf-8')

--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -19,8 +19,10 @@
 """ OSP XML utils class.
 """
 
+
 from typing import List, Dict, Any, Union
 
+from xml.sax.saxutils import escape
 from xml.etree.ElementTree import tostring, Element
 
 from ospd.misc import ResultType
@@ -46,8 +48,9 @@ def get_result_xml(result):
         ('port', result['port']),
         ('qod', result['qod']),
     ]:
-        result_xml.set(name, str(value))
+        result_xml.set(name, escape(str(value)))
     result_xml.text = result['value']
+
     return result_xml
 
 
@@ -71,7 +74,7 @@ def simple_response_str(
     response = Element('%s_response' % command)
 
     for name, value in [('status', str(status)), ('status_text', status_text)]:
-        response.set(name, str(value))
+        response.set(name, escape(str(value)))
 
     if isinstance(content, list):
         for elem in content:


### PR DESCRIPTION
since the default encoding format for xml.etree.Element.tostring() is us-ascii.
Escape attributes values too.