### PR TITLE
Improve test

### DIFF
--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -690,11 +690,10 @@ class ScanTestCase(unittest.TestCase):
             scan = scans[0]
             status = scan.get('status')
 
-            if status == "init" or status == "running":
-                self.assertEqual('0', scan.get('end_time'))
-                time.sleep(0.010)
-            else:
+            if scan.get('end_time') != '0':
                 finished = True
+            else:
+                time.sleep(0.01)
 
         self.fs.clean_response()
         daemon.handle_command(


### PR DESCRIPTION
Avoid a race condition, when the status is not changed but it has already an end_time
Remove the assert, since this is not supposed to be tested by this test.