### PR TITLE
Copy the vts for calculation

### DIFF
--- a/ospd/vts.py
+++ b/ospd/vts.py
@@ -192,8 +192,8 @@ class Vts:
             return
 
         m = sha256()
-
-        for vt_id, vt in sorted(self._vts.items()):
+        temp_vts = self.vts.copy()
+        for vt_id, vt in sorted(temp_vts.items()):
             param_chain = ""
             vt_params = vt.get('vt_params')
             if include_vt_params and vt_params:


### PR DESCRIPTION
If the original vts collection is sorted for the calculation, the vts collection is copied into the main process. So, a deep copy is made to be sorted and released at the end. This generates a memory usage peak during time interval. 