### PR TITLE
Don't sort the vts for hash calculation.

### DIFF
--- a/ospd/vts.py
+++ b/ospd/vts.py
@@ -192,8 +192,9 @@ class Vts:
             return
 
         m = sha256()
-        temp_vts = self.vts.copy()
-        for vt_id, vt in sorted(temp_vts.items()):
+
+        # The vts must already sorted in the dictionary.
+        for vt_id, vt in self.vts.items():
             param_chain = ""
             vt_params = vt.get('vt_params')
             if include_vt_params and vt_params:

--- a/ospd/vts.py
+++ b/ospd/vts.py
@@ -193,7 +193,8 @@ class Vts:
 
         m = sha256()
 
-        # The vts must already sorted in the dictionary.
+        # for a reproducable hash calculation
+        # the vts must already be sorted in the dictionary.
         for vt_id, vt in self.vts.items():
             param_chain = ""
             vt_params = vt.get('vt_params')

--- a/tests/test_vts.py
+++ b/tests/test_vts.py
@@ -143,7 +143,6 @@ class VtsTestCase(TestCase):
     def test_calculate_vts_collection_hash(self):
         vts = Vts()
 
-        vts.add('id_2', name='bar', vt_modification_time='56789')
         vts.add(
             'id_1',
             name='foo',
@@ -153,12 +152,36 @@ class VtsTestCase(TestCase):
                 '1': {'id': '1', 'name': 'foo_pref:', 'default': 'bar_value',},
             },
         )
+        vts.add('id_2', name='bar', vt_modification_time='56789')
+
         vts.calculate_vts_collection_hash()
 
         h = sha256()
         h.update(
             "id_1012340timeout201foo_pref:bar_valueid_256789".encode('utf-8')
         )
+        hash_test = h.hexdigest()
+
+        self.assertEqual(hash_test, vts.sha256_hash)
+
+    def test_calculate_vts_collection_hash_no_params(self):
+        vts = Vts()
+
+        vts.add(
+            'id_1',
+            name='foo',
+            vt_modification_time='01234',
+            vt_params={
+                '0': {'id': '0', 'name': 'timeout', 'default': '20',},
+                '1': {'id': '1', 'name': 'foo_pref:', 'default': 'bar_value',},
+            },
+        )
+        vts.add('id_2', name='bar', vt_modification_time='56789')
+
+        vts.calculate_vts_collection_hash(include_vt_params=False)
+
+        h = sha256()
+        h.update("id_101234id_256789".encode('utf-8'))
         hash_test = h.hexdigest()
 
         self.assertEqual(hash_test, vts.sha256_hash)


### PR DESCRIPTION
Preserve the order in which the vts were added to the dictionary. This avoid the copy of the dictionary to be sorted.
Also update the test, and add a new one to test the include_vt_params= False