### PR TITLE
Add support for updating results, finished hosts and host progresses in batch.

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -517,7 +517,7 @@ class OSPDaemon:
         exc_hosts_list = target_str_to_list(finished_hosts)
 
         for host in exc_hosts_list:
-            self.set_scan_host_finished(scan_id, host)
+            self.set_scan_host_finished(scan_id, host=host)
             self.set_scan_host_progress(scan_id, host=host, progress=100)
 
     def start_scan(self, scan_id: str, target: Dict) -> None:
@@ -583,9 +583,17 @@ class OSPDaemon:
             scan_id, exc_hosts_list
         )
 
-    def set_scan_host_finished(self, scan_id: str, host: str) -> None:
+    def set_scan_host_finished(
+        self,
+        scan_id: str,
+        host: str = None,
+        finished_host_batch: List[str] = None,
+    ) -> None:
         """ Add the host in a list of finished hosts """
-        self.scan_collection.set_host_finished(scan_id, host)
+        if host:
+            finished_host_batch = [host]
+
+        self.scan_collection.set_host_finished(scan_id, finished_host_batch)
 
     def set_scan_progress(self, scan_id: str, progress: int) -> None:
         """ Sets scan_id scan's progress which is a number

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1277,7 +1277,7 @@ class OSPDaemon:
 
     def add_scan_log(
         self,
-        scan_id: str,
+        scan_id: str = '',
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -1302,7 +1302,7 @@ class OSPDaemon:
 
     def add_scan_error(
         self,
-        scan_id: str,
+        scan_id: str = '',
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -1324,7 +1324,7 @@ class OSPDaemon:
 
     def add_scan_host_detail(
         self,
-        scan_id: str,
+        scan_id: str = '',
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -1337,7 +1337,7 @@ class OSPDaemon:
 
     def add_scan_alarm(
         self,
-        scan_id: str,
+        scan_id: str = '',
         host: str = '',
         hostname: str = '',
         name: str = '',

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -598,26 +598,26 @@ class OSPDaemon:
         between 0 and 100. """
         self.scan_collection.set_progress(scan_id, progress)
 
+    def set_scan_progress_batch(
+        self, scan_id: str, host_progress: Dict[str, int]
+    ):
+        self.scan_collection.set_host_progress(scan_id, host_progress)
+
+        scan_progress = self.calculate_progress(scan_id)
+        self.set_scan_progress(scan_id, scan_progress)
+
     def set_scan_host_progress(
-        self,
-        scan_id: str,
-        host: str = None,
-        progress: int = None,
-        host_progress_batch: Dict[str, int] = None,
+        self, scan_id: str, host: str = None, progress: int = None,
     ) -> None:
         """ Sets host's progress which is part of target.
         Each time a host progress is updated, the scan progress
         is updated too.
         """
-        if host and progress > 0 and progress <= 100:
-            host_progress_batch = {host: progress}
-        elif host_progress_batch is None:
+        if host and progress < 0 or progress > 100:
             return
 
-        self.scan_collection.set_host_progress(scan_id, host_progress_batch)
-
-        scan_progress = self.calculate_progress(scan_id)
-        self.set_scan_progress(scan_id, scan_progress)
+        host_progress = {host: progress}
+        self.set_scan_progress_batch(scan_id, host_progress)
 
     def set_scan_status(self, scan_id: str, status: ScanStatus) -> None:
         """ Set the scan's status."""

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1293,7 +1293,7 @@ class OSPDaemon:
 
     def add_scan_log(
         self,
-        scan_id: str = '',
+        scan_id: str,
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -1301,25 +1301,8 @@ class OSPDaemon:
         port: str = '',
         test_id: str = '',
         qod: str = '',
-        batch: bool = False,
-        result_batch: Optional[List] = None,
-    ) -> Optional[List[Dict[str, str]]]:
+    ) -> None:
         """ Adds a log result to scan_id scan. """
-
-        if batch:
-            result_batch = self.add_result_to_batch(
-                result_batch,
-                ResultType.LOG,
-                host,
-                hostname,
-                name,
-                value,
-                port,
-                test_id,
-                '0.0',
-                qod,
-            )
-            return result_batch
 
         self.scan_collection.add_result(
             scan_id,
@@ -1334,33 +1317,43 @@ class OSPDaemon:
             qod,
         )
 
+    def add_scan_log_to_list(
+        self,
+        result_list: List,
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        qod: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds log result to a list of results. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.LOG,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+            '0.0',
+            qod,
+        )
+        return result_list
+
     def add_scan_error(
         self,
-        scan_id: str = '',
+        scan_id: str,
         host: str = '',
         hostname: str = '',
         name: str = '',
         value: str = '',
         port: str = '',
         test_id='',
-        batch: bool = False,
-        result_batch: Optional[List] = None,
-    ) -> Optional[List[Dict[str, str]]]:
+    ) -> None:
         """ Adds an error result to scan_id scan. """
-
-        if batch:
-            result_batch = self.add_result_to_batch(
-                result_batch,
-                ResultType.ERROR,
-                host,
-                hostname,
-                name,
-                value,
-                port,
-                test_id,
-            )
-            return result_batch
-
         self.scan_collection.add_result(
             scan_id,
             ResultType.ERROR,
@@ -1372,36 +1365,59 @@ class OSPDaemon:
             test_id,
         )
 
-    def add_scan_host_detail(
+    def add_scan_error_to_list(
         self,
-        scan_id: str = '',
+        result_list: Optional[List],
         host: str = '',
         hostname: str = '',
         name: str = '',
         value: str = '',
-        batch: bool = False,
-        result_batch: Optional[List] = None,
-    ) -> Optional[List[Dict[str, str]]]:
+        port: str = '',
+        test_id='',
+    ) -> List[Dict[str, str]]:
+        """ Adds an error result to result list. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.ERROR,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+        )
+        return result_list
+
+    def add_scan_host_detail(
+        self,
+        scan_id: str,
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+    ) -> None:
         """ Adds a host detail result to scan_id scan. """
-
-        if batch:
-            result_batch = self.add_result_to_batch(
-                result_batch,
-                ResultType.HOST_DETAIL,
-                host,
-                hostname,
-                name,
-                value,
-            )
-            return result_batch
-
         self.scan_collection.add_result(
             scan_id, ResultType.HOST_DETAIL, host, hostname, name, value
         )
 
+    def add_scan_host_detail_to_list(
+        self,
+        result_list: Optional[List] = None,
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds a host detail result to result list. """
+        result_list = self.add_result_to_list(
+            result_list, ResultType.HOST_DETAIL, host, hostname, name, value,
+        )
+        return result_list
+
     def add_scan_alarm(
         self,
-        scan_id: str = '',
+        scan_id: str,
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -1410,26 +1426,8 @@ class OSPDaemon:
         test_id: str = '',
         severity: str = '',
         qod: str = '',
-        batch: bool = False,
-        result_batch: Optional[List] = None,
-    ) -> Optional[List[Dict[str, str]]]:
+    ) -> None:
         """ Adds an alarm result to scan_id scan. """
-
-        if batch:
-            result_batch = self.add_result_to_batch(
-                result_batch,
-                ResultType.ALARM,
-                host,
-                hostname,
-                name,
-                value,
-                port,
-                test_id,
-                severity,
-                qod,
-            )
-            return result_batch
-
         self.scan_collection.add_result(
             scan_id,
             ResultType.ALARM,
@@ -1443,7 +1441,34 @@ class OSPDaemon:
             qod,
         )
 
-    def add_result_to_batch(
+    def add_scan_alarm_to_list(
+        self,
+        result_list: Optional[List],
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        severity: str = '',
+        qod: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds an alarm result to a result list. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.ALARM,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+            severity,
+            qod,
+        )
+        return result_list
+
+    def add_result_to_list(
         self,
         results: List[Dict[str, str]],
         result_type: int,
@@ -1455,7 +1480,6 @@ class OSPDaemon:
         test_id: str = '',
         severity: str = '',
         qod: str = '',
-        batch: bool = False,
     ) -> List[Dict[str, str]]:
 
         result = OrderedDict()  # type: Dict

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -27,7 +27,6 @@ import multiprocessing
 import time
 import os
 
-from collections import OrderedDict
 from typing import (
     List,
     Any,
@@ -1317,32 +1316,6 @@ class OSPDaemon:
             qod,
         )
 
-    def add_scan_log_to_list(
-        self,
-        result_list: List,
-        host: str = '',
-        hostname: str = '',
-        name: str = '',
-        value: str = '',
-        port: str = '',
-        test_id: str = '',
-        qod: str = '',
-    ) -> List[Dict[str, str]]:
-        """ Adds log result to a list of results. """
-        result_list = self.add_result_to_list(
-            result_list,
-            ResultType.LOG,
-            host,
-            hostname,
-            name,
-            value,
-            port,
-            test_id,
-            '0.0',
-            qod,
-        )
-        return result_list
-
     def add_scan_error(
         self,
         scan_id: str,
@@ -1365,29 +1338,6 @@ class OSPDaemon:
             test_id,
         )
 
-    def add_scan_error_to_list(
-        self,
-        result_list: Optional[List],
-        host: str = '',
-        hostname: str = '',
-        name: str = '',
-        value: str = '',
-        port: str = '',
-        test_id='',
-    ) -> List[Dict[str, str]]:
-        """ Adds an error result to result list. """
-        result_list = self.add_result_to_list(
-            result_list,
-            ResultType.ERROR,
-            host,
-            hostname,
-            name,
-            value,
-            port,
-            test_id,
-        )
-        return result_list
-
     def add_scan_host_detail(
         self,
         scan_id: str,
@@ -1400,20 +1350,6 @@ class OSPDaemon:
         self.scan_collection.add_result(
             scan_id, ResultType.HOST_DETAIL, host, hostname, name, value
         )
-
-    def add_scan_host_detail_to_list(
-        self,
-        result_list: Optional[List] = None,
-        host: str = '',
-        hostname: str = '',
-        name: str = '',
-        value: str = '',
-    ) -> List[Dict[str, str]]:
-        """ Adds a host detail result to result list. """
-        result_list = self.add_result_to_list(
-            result_list, ResultType.HOST_DETAIL, host, hostname, name, value,
-        )
-        return result_list
 
     def add_scan_alarm(
         self,
@@ -1440,61 +1376,3 @@ class OSPDaemon:
             severity,
             qod,
         )
-
-    def add_scan_alarm_to_list(
-        self,
-        result_list: Optional[List],
-        host: str = '',
-        hostname: str = '',
-        name: str = '',
-        value: str = '',
-        port: str = '',
-        test_id: str = '',
-        severity: str = '',
-        qod: str = '',
-    ) -> List[Dict[str, str]]:
-        """ Adds an alarm result to a result list. """
-        result_list = self.add_result_to_list(
-            result_list,
-            ResultType.ALARM,
-            host,
-            hostname,
-            name,
-            value,
-            port,
-            test_id,
-            severity,
-            qod,
-        )
-        return result_list
-
-    def add_result_to_list(
-        self,
-        results: List[Dict[str, str]],
-        result_type: int,
-        host: str = '',
-        hostname: str = '',
-        name: str = '',
-        value: str = '',
-        port: str = '',
-        test_id: str = '',
-        severity: str = '',
-        qod: str = '',
-    ) -> List[Dict[str, str]]:
-
-        result = OrderedDict()  # type: Dict
-        result['type'] = result_type
-        result['name'] = name
-        result['severity'] = severity
-        result['test_id'] = test_id
-        result['value'] = value
-        result['host'] = host
-        result['hostname'] = hostname
-        result['port'] = port
-        result['qod'] = qod
-
-        if results is None:
-            results = list()
-        results.append(result)
-
-        return results

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1285,8 +1285,26 @@ class OSPDaemon:
         port: str = '',
         test_id: str = '',
         qod: str = '',
-    ):
+        batch: bool = False,
+        result_batch: Optional[List] = None,
+    ) -> Optional[List[Dict[str, str]]]:
         """ Adds a log result to scan_id scan. """
+
+        if batch:
+            result_batch = self.add_result_to_batch(
+                result_batch,
+                ResultType.LOG,
+                host,
+                hostname,
+                name,
+                value,
+                port,
+                test_id,
+                '0.0',
+                qod,
+            )
+            return result_batch
+
         self.scan_collection.add_result(
             scan_id,
             ResultType.LOG,
@@ -1309,8 +1327,24 @@ class OSPDaemon:
         value: str = '',
         port: str = '',
         test_id='',
-    ) -> None:
+        batch: bool = False,
+        result_batch: Optional[List] = None,
+    ) -> Optional[List[Dict[str, str]]]:
         """ Adds an error result to scan_id scan. """
+
+        if batch:
+            result_batch = self.add_result_to_batch(
+                result_batch,
+                ResultType.ERROR,
+                host,
+                hostname,
+                name,
+                value,
+                port,
+                test_id,
+            )
+            return result_batch
+
         self.scan_collection.add_result(
             scan_id,
             ResultType.ERROR,
@@ -1329,8 +1363,22 @@ class OSPDaemon:
         hostname: str = '',
         name: str = '',
         value: str = '',
-    ) -> None:
+        batch: bool = False,
+        result_batch: Optional[List] = None,
+    ) -> Optional[List[Dict[str, str]]]:
         """ Adds a host detail result to scan_id scan. """
+
+        if batch:
+            result_batch = self.add_result_to_batch(
+                result_batch,
+                ResultType.HOST_DETAIL,
+                host,
+                hostname,
+                name,
+                value,
+            )
+            return result_batch
+
         self.scan_collection.add_result(
             scan_id, ResultType.HOST_DETAIL, host, hostname, name, value
         )
@@ -1346,8 +1394,26 @@ class OSPDaemon:
         test_id: str = '',
         severity: str = '',
         qod: str = '',
-    ):
+        batch: bool = False,
+        result_batch: Optional[List] = None,
+    ) -> Optional[List[Dict[str, str]]]:
         """ Adds an alarm result to scan_id scan. """
+
+        if batch:
+            result_batch = self.add_result_to_batch(
+                result_batch,
+                ResultType.ALARM,
+                host,
+                hostname,
+                name,
+                value,
+                port,
+                test_id,
+                severity,
+                qod,
+            )
+            return result_batch
+
         self.scan_collection.add_result(
             scan_id,
             ResultType.ALARM,

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -518,7 +518,7 @@ class OSPDaemon:
 
         for host in exc_hosts_list:
             self.set_scan_host_finished(scan_id, host)
-            self.set_scan_host_progress(scan_id, host, 100)
+            self.set_scan_host_progress(scan_id, host=host, progress=100)
 
     def start_scan(self, scan_id: str, target: Dict) -> None:
         """ Starts the scan with scan_id. """
@@ -593,13 +593,22 @@ class OSPDaemon:
         self.scan_collection.set_progress(scan_id, progress)
 
     def set_scan_host_progress(
-        self, scan_id: str, host: str, progress: int
+        self,
+        scan_id: str,
+        host: str = None,
+        progress: int = None,
+        host_progress_batch: Dict[str, int] = None,
     ) -> None:
         """ Sets host's progress which is part of target.
         Each time a host progress is updated, the scan progress
         is updated too.
         """
-        self.scan_collection.set_host_progress(scan_id, host, progress)
+        if host and progress > 0 and progress <= 100:
+            host_progress_batch = {host: progress}
+        elif host_progress_batch is None:
+            return
+
+        self.scan_collection.set_host_progress(scan_id, host_progress_batch)
 
         scan_progress = self.calculate_progress(scan_id)
         self.set_scan_progress(scan_id, scan_progress)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -27,6 +27,7 @@ import multiprocessing
 import time
 import os
 
+from collections import OrderedDict
 from typing import (
     List,
     Any,
@@ -1426,3 +1427,35 @@ class OSPDaemon:
             severity,
             qod,
         )
+
+    def add_result_to_batch(
+        self,
+        results: List[Dict[str, str]],
+        result_type: int,
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        severity: str = '',
+        qod: str = '',
+        batch: bool = False,
+    ) -> List[Dict[str, str]]:
+
+        result = OrderedDict()  # type: Dict
+        result['type'] = result_type
+        result['name'] = name
+        result['severity'] = severity
+        result['test_id'] = test_id
+        result['value'] = value
+        result['host'] = host
+        result['hostname'] = hostname
+        result['port'] = port
+        result['qod'] = qod
+
+        if results is None:
+            results = list()
+        results.append(result)
+
+        return results

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -36,6 +36,7 @@ from typing import (
     Optional,
     Iterable,
     Tuple,
+    Union,
 )
 from xml.etree.ElementTree import Element, SubElement
 
@@ -517,7 +518,7 @@ class OSPDaemon:
         exc_hosts_list = target_str_to_list(finished_hosts)
 
         for host in exc_hosts_list:
-            self.set_scan_host_finished(scan_id, host=host)
+            self.set_scan_host_finished(scan_id, finished_hosts=host)
             self.set_scan_host_progress(scan_id, host=host, progress=100)
 
     def start_scan(self, scan_id: str, target: Dict) -> None:
@@ -584,16 +585,13 @@ class OSPDaemon:
         )
 
     def set_scan_host_finished(
-        self,
-        scan_id: str,
-        host: str = None,
-        finished_host_batch: List[str] = None,
+        self, scan_id: str, finished_hosts: Union[List[str], str],
     ) -> None:
         """ Add the host in a list of finished hosts """
-        if host:
-            finished_host_batch = [host]
+        if isinstance(finished_hosts, str):
+            finished_hosts = [finished_hosts]
 
-        self.scan_collection.set_host_finished(scan_id, finished_host_batch)
+        self.scan_collection.set_host_finished(scan_id, finished_hosts)
 
     def set_scan_progress(self, scan_id: str, progress: int) -> None:
         """ Sets scan_id scan's progress which is a number

--- a/ospd/resultlist.py
+++ b/ospd/resultlist.py
@@ -32,46 +32,37 @@ from ospd.misc import ResultType
 class ResultList:
     """ Class for handling list of resutls."""
 
+    def __init__(self):
+        self._result_list = list()
+
     def add_scan_host_detail_to_list(
         self,
-        result_list: Optional[List],
         host: str = '',
         hostname: str = '',
         name: str = '',
         value: str = '',
-    ) -> List[Dict[str, str]]:
+    ) -> None:
         """ Adds a host detail result to result list. """
-        result_list = self.add_result_to_list(
-            result_list, ResultType.HOST_DETAIL, host, hostname, name, value,
+        self.add_result_to_list(
+            ResultType.HOST_DETAIL, host, hostname, name, value,
         )
-        return result_list
 
     def add_scan_error_to_list(
         self,
-        result_list: Optional[List],
         host: str = '',
         hostname: str = '',
         name: str = '',
         value: str = '',
         port: str = '',
         test_id='',
-    ) -> List[Dict[str, str]]:
+    ) -> None:
         """ Adds an error result to result list. """
-        result_list = self.add_result_to_list(
-            result_list,
-            ResultType.ERROR,
-            host,
-            hostname,
-            name,
-            value,
-            port,
-            test_id,
+        self.add_result_to_list(
+            ResultType.ERROR, host, hostname, name, value, port, test_id,
         )
-        return result_list
 
     def add_scan_log_to_list(
         self,
-        result_list: Optional[List],
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -79,10 +70,9 @@ class ResultList:
         port: str = '',
         test_id: str = '',
         qod: str = '',
-    ) -> List[Dict[str, str]]:
+    ) -> None:
         """ Adds log result to a list of results. """
-        result_list = self.add_result_to_list(
-            result_list,
+        self.add_result_to_list(
             ResultType.LOG,
             host,
             hostname,
@@ -93,11 +83,9 @@ class ResultList:
             '0.0',
             qod,
         )
-        return result_list
 
     def add_scan_alarm_to_list(
         self,
-        result_list: Optional[List],
         host: str = '',
         hostname: str = '',
         name: str = '',
@@ -106,10 +94,9 @@ class ResultList:
         test_id: str = '',
         severity: str = '',
         qod: str = '',
-    ) -> List[Dict[str, str]]:
+    ) -> None:
         """ Adds an alarm result to a result list. """
-        result_list = self.add_result_to_list(
-            result_list,
+        self.add_result_to_list(
             ResultType.ALARM,
             host,
             hostname,
@@ -120,11 +107,9 @@ class ResultList:
             severity,
             qod,
         )
-        return result_list
 
     def add_result_to_list(
         self,
-        results: List[Dict[str, str]],
         result_type: int,
         host: str = '',
         hostname: str = '',
@@ -134,7 +119,7 @@ class ResultList:
         test_id: str = '',
         severity: str = '',
         qod: str = '',
-    ) -> List[Dict[str, str]]:
+    ) -> None:
 
         result = OrderedDict()  # type: Dict
         result['type'] = result_type
@@ -147,8 +132,7 @@ class ResultList:
         result['port'] = port
         result['qod'] = qod
 
-        if results is None:
-            results = list()
-        results.append(result)
+        self._result_list.append(result)
 
-        return results
+    def __iter__(self):
+        return iter(self._result_list)

--- a/ospd/resultlist.py
+++ b/ospd/resultlist.py
@@ -1,0 +1,154 @@
+# Copyright (C) 2014-2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=too-many-lines
+
+""" Class for handling list of resutls.
+"""
+
+from collections import OrderedDict
+from typing import (
+    List,
+    Dict,
+    Optional,
+)
+from ospd.misc import ResultType
+
+
+class ResultList:
+    """ Class for handling list of resutls."""
+
+    def add_scan_host_detail_to_list(
+        self,
+        result_list: Optional[List],
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds a host detail result to result list. """
+        result_list = self.add_result_to_list(
+            result_list, ResultType.HOST_DETAIL, host, hostname, name, value,
+        )
+        return result_list
+
+    def add_scan_error_to_list(
+        self,
+        result_list: Optional[List],
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id='',
+    ) -> List[Dict[str, str]]:
+        """ Adds an error result to result list. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.ERROR,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+        )
+        return result_list
+
+    def add_scan_log_to_list(
+        self,
+        result_list: Optional[List],
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        qod: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds log result to a list of results. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.LOG,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+            '0.0',
+            qod,
+        )
+        return result_list
+
+    def add_scan_alarm_to_list(
+        self,
+        result_list: Optional[List],
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        severity: str = '',
+        qod: str = '',
+    ) -> List[Dict[str, str]]:
+        """ Adds an alarm result to a result list. """
+        result_list = self.add_result_to_list(
+            result_list,
+            ResultType.ALARM,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
+            severity,
+            qod,
+        )
+        return result_list
+
+    def add_result_to_list(
+        self,
+        results: List[Dict[str, str]],
+        result_type: int,
+        host: str = '',
+        hostname: str = '',
+        name: str = '',
+        value: str = '',
+        port: str = '',
+        test_id: str = '',
+        severity: str = '',
+        qod: str = '',
+    ) -> List[Dict[str, str]]:
+
+        result = OrderedDict()  # type: Dict
+        result['type'] = result_type
+        result['name'] = name
+        result['severity'] = severity
+        result['test_id'] = test_id
+        result['value'] = value
+        result['host'] = host
+        result['hostname'] = hostname
+        result['port'] = port
+        result['qod'] = qod
+
+        if results is None:
+            results = list()
+        results.append(result)
+
+        return results

--- a/ospd/resultlist.py
+++ b/ospd/resultlist.py
@@ -35,6 +35,9 @@ class ResultList:
     def __init__(self):
         self._result_list = list()
 
+    def __len__(self):
+        return len(self._result_list)
+
     def add_scan_host_detail_to_list(
         self,
         host: str = '',

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -97,6 +97,16 @@ class ScanCollection:
         # Set scan_info's results to propagate results to parent process.
         self.scans_table[scan_id]['results'] = results
 
+    def add_result_batch(
+        self, scan_id: str, result_batch: List[Dict[str, str]]
+    ) -> None:
+        """ Add a batch of results to the result's table for the corresponding scan_id """
+        results = self.scans_table[scan_id]['results']
+        results.extend(result_batch)
+
+        # Set scan_info's results to propagate results to parent process.
+        self.scans_table[scan_id]['results'] = results
+
     def remove_hosts_from_target_progress(
         self, scan_id: str, hosts: List
     ) -> None:

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -144,14 +144,13 @@ class ScanCollection:
         # to parent process.
         self.scans_table[scan_id]['target_progress'] = host_progresses
 
-    def set_host_finished(self, scan_id: str, host: str) -> None:
+    def set_host_finished(self, scan_id: str, hosts: List[str]) -> None:
         """ Add the host in a list of finished hosts """
         finished_hosts = self.scans_table[scan_id].get('finished_hosts')
+        finished_hosts.extend(hosts)
+        uniq_set_of_hosts = set(finished_hosts)
 
-        if host not in finished_hosts:
-            finished_hosts.append(host)
-
-        self.scans_table[scan_id]['finished_hosts'] = finished_hosts
+        self.scans_table[scan_id]['finished_hosts'] = list(uniq_set_of_hosts)
 
     def get_hosts_unfinished(self, scan_id: str) -> List[Any]:
         """ Get a list of unfinished hosts."""

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -133,14 +133,16 @@ class ScanCollection:
         if progress == 100:
             self.scans_table[scan_id]['end_time'] = int(time.time())
 
-    def set_host_progress(self, scan_id: str, host: str, progress: int) -> None:
+    def set_host_progress(
+        self, scan_id: str, host_progress_batch: Dict[str, int]
+    ) -> None:
         """ Sets scan_id scan's progress. """
-        if progress > 0 and progress <= 100:
-            host_progresses = self.scans_table[scan_id].get('target_progress')
-            host_progresses[host] = progress
-            # Set scan_info's target_progress to propagate progresses
-            # to parent process.
-            self.scans_table[scan_id]['target_progress'] = host_progresses
+        host_progresses = self.scans_table[scan_id].get('target_progress')
+        host_progresses.update(host_progress_batch)
+
+        # Set scan_info's target_progress to propagate progresses
+        # to parent process.
+        self.scans_table[scan_id]['target_progress'] = host_progresses
 
     def set_host_finished(self, scan_id: str, host: str) -> None:
         """ Add the host in a list of finished hosts """

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -22,7 +22,7 @@ import uuid
 
 from collections import OrderedDict
 from enum import Enum
-from typing import List, Any, Dict, Iterator, Optional
+from typing import List, Any, Dict, Iterator, Optional, Iterable
 
 from ospd.network import target_str_to_list
 
@@ -98,7 +98,7 @@ class ScanCollection:
         self.scans_table[scan_id]['results'] = results
 
     def add_result_list(
-        self, scan_id: str, result_list: List[Dict[str, str]]
+        self, scan_id: str, result_list: Iterable[Dict[str, str]]
     ) -> None:
         """ Add a batch of results to the result's table for the corresponding scan_id """
         results = self.scans_table[scan_id]['results']

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -97,12 +97,12 @@ class ScanCollection:
         # Set scan_info's results to propagate results to parent process.
         self.scans_table[scan_id]['results'] = results
 
-    def add_result_batch(
-        self, scan_id: str, result_batch: List[Dict[str, str]]
+    def add_result_list(
+        self, scan_id: str, result_list: List[Dict[str, str]]
     ) -> None:
         """ Add a batch of results to the result's table for the corresponding scan_id """
         results = self.scans_table[scan_id]['results']
-        results.extend(result_batch)
+        results.extend(result_list)
 
         # Set scan_info's results to propagate results to parent process.
         self.scans_table[scan_id]['results'] = results

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -31,6 +31,7 @@ import defusedxml.lxml as secET
 from defusedxml.common import EntitiesForbidden
 
 from .helper import DummyWrapper, assert_called, FakeStream
+from ospd.resultlist import ResultList
 
 
 class FakeStartProcess:
@@ -962,6 +963,7 @@ class ScanTestCase(unittest.TestCase):
 
     def test_batch_result(self):
         daemon = DummyWrapper([])
+        reslist = ResultList()
         fs = FakeStream()
         daemon.handle_command(
             '<start_scan parallel="1">'
@@ -978,13 +980,13 @@ class ScanTestCase(unittest.TestCase):
 
         scan_id = response.findtext('id')
         result_list = list()
-        result_list = daemon.add_scan_log_to_list(
+        result_list = reslist.add_scan_log_to_list(
             result_list, host='a', name='a'
         )
-        result_list = daemon.add_scan_log_to_list(
+        result_list = reslist.add_scan_log_to_list(
             result_list, host='c', name='c'
         )
-        result_list = daemon.add_scan_log_to_list(
+        result_list = reslist.add_scan_log_to_list(
             result_list, host='b', name='b'
         )
         daemon.scan_collection.add_result_list(scan_id, result_list)

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -979,17 +979,10 @@ class ScanTestCase(unittest.TestCase):
         response = fs.get_response()
 
         scan_id = response.findtext('id')
-        result_list = list()
-        result_list = reslist.add_scan_log_to_list(
-            result_list, host='a', name='a'
-        )
-        result_list = reslist.add_scan_log_to_list(
-            result_list, host='c', name='c'
-        )
-        result_list = reslist.add_scan_log_to_list(
-            result_list, host='b', name='b'
-        )
-        daemon.scan_collection.add_result_list(scan_id, result_list)
+        reslist.add_scan_log_to_list(host='a', name='a')
+        reslist.add_scan_log_to_list(host='c', name='c')
+        reslist.add_scan_log_to_list(host='b', name='b')
+        daemon.scan_collection.add_result_list(scan_id, reslist)
 
         hosts = ['a', 'c', 'b']
 

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -801,7 +801,9 @@ class ScanTestCase(unittest.TestCase):
         scan_id = response.findtext('id')
         time.sleep(1)
         finished = daemon.get_scan_finished_hosts(scan_id)
-        self.assertEqual(finished, ['192.168.10.23', '192.168.10.24'])
+        for host in ['192.168.10.23', '192.168.10.24']:
+            self.assertIn(host, finished)
+        self.assertEqual(len(finished), 2)
 
     def test_progress(self):
         daemon = DummyWrapper([])

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -977,17 +977,17 @@ class ScanTestCase(unittest.TestCase):
         response = fs.get_response()
 
         scan_id = response.findtext('id')
-        result_batch = list()
-        result_batch = daemon.add_scan_log(
-            host='a', name='a', batch=True, result_batch=result_batch
+        result_list = list()
+        result_list = daemon.add_scan_log_to_list(
+            result_list, host='a', name='a'
         )
-        result_batch = daemon.add_scan_log(
-            host='c', name='c', batch=True, result_batch=result_batch
+        result_list = daemon.add_scan_log_to_list(
+            result_list, host='c', name='c'
         )
-        result_batch = daemon.add_scan_log(
-            host='b', name='b', batch=True, result_batch=result_batch
+        result_list = daemon.add_scan_log_to_list(
+            result_list, host='b', name='b'
         )
-        daemon.scan_collection.add_result_batch(scan_id, result_batch)
+        daemon.scan_collection.add_result_list(scan_id, result_list)
 
         hosts = ['a', 'c', 'b']
 

--- a/tests/test_vts.py
+++ b/tests/test_vts.py
@@ -20,6 +20,7 @@ import logging
 from unittest import TestCase
 from unittest.mock import Mock
 
+from collections import OrderedDict
 from ospd.errors import OspdError
 from ospd.vts import Vts
 from hashlib import sha256
@@ -140,7 +141,7 @@ class VtsTestCase(TestCase):
         self.assertIsNot(vta, vtb)
 
     def test_calculate_vts_collection_hash(self):
-        vts = Vts()
+        vts = Vts(storage=OrderedDict())
 
         vts.add(
             'id_1',
@@ -164,7 +165,7 @@ class VtsTestCase(TestCase):
         self.assertEqual(hash_test, vts.sha256_hash)
 
     def test_calculate_vts_collection_hash_no_params(self):
-        vts = Vts()
+        vts = Vts(storage=OrderedDict())
 
         vts.add(
             'id_1',


### PR DESCRIPTION
This allows to access the scan table less time. As the scan table is in a separated process, accessing the shared memory makes the writing of result for large scan quite slow.
Now this is improved.