### PR TITLE
Check for max scans before starting a new scan

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -466,7 +466,7 @@ class StartScan(BaseCommand):
 
     def is_new_scan_allowed(self) -> bool:
         """ Check if max_scans has been reached.
-        
+
         Return:
             True if a new scan can be launch.
         """
@@ -477,12 +477,38 @@ class StartScan(BaseCommand):
 
         return False
 
+    def is_enough_free_memory(self) -> bool:
+        """ Check if there is enough free memory in the system to run
+        a new scan. The necessary memory is a rough calculation and very
+        conservative.
+
+        Return:
+            True if there is enough memory for a new scan.
+        """
+
+        ps_process = psutil.Process()
+        proc_memory = ps_process.memory_info().rss
+
+        free_mem = psutil.virtual_memory().free
+
+        if free_mem > (4 * proc_memory):
+            return True
+
+        return False
+
     def handle_xml(self, xml: Element) -> bytes:
         """ Handles <start_scan> command.
 
         Return:
             Response string for <start_scan> command.
         """
+
+        if self._daemon.check_free_memory and not self.is_enough_free_memory():
+            raise OspdCommandError(
+                'Not possible to run a new scan. Not enough free memory.',
+                'start_scan',
+            )
+
         if not self.is_new_scan_allowed():
             raise OspdCommandError(
                 'Not possible to run a new scan. Max scan limit reached.',

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -464,12 +464,30 @@ class StartScan(BaseCommand):
 
         return elements
 
+    def is_new_scan_allowed(self) -> bool:
+        """ Check if max_scans has been reached.
+        
+        Return:
+            True if a new scan can be launch.
+        """
+        if (self._daemon.max_scans == 0) or (
+            len(self._daemon.scan_processes) < self._daemon.max_scans
+        ):
+            return True
+
+        return False
+
     def handle_xml(self, xml: Element) -> bytes:
         """ Handles <start_scan> command.
 
         Return:
             Response string for <start_scan> command.
         """
+        if not self.is_new_scan_allowed():
+            raise OspdCommandError(
+                'Not possible to run a new scan. Max scan limit reached.',
+                'start_scan',
+            )
 
         target_str = xml.get('target')
         ports_str = xml.get('ports')

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -107,7 +107,7 @@ class OSPDaemon:
     """
 
     def __init__(
-        self, *, customvtfilter=None, **kwargs
+        self, *, customvtfilter=None, max_scans=0, **kwargs
     ):  # pylint: disable=unused-argument
         """ Initializes the daemon's internal data. """
         self.scan_collection = ScanCollection()
@@ -126,6 +126,8 @@ class OSPDaemon:
         self.server_version = None  # Set by the subclass.
 
         self.initialized = None  # Set after initialization finished
+
+        self.max_scans = max_scans
 
         self.scaninfo_store_time = kwargs.get('scaninfo_store_time')
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -107,7 +107,12 @@ class OSPDaemon:
     """
 
     def __init__(
-        self, *, customvtfilter=None, max_scans=0, **kwargs
+        self,
+        *,
+        customvtfilter=None,
+        max_scans=0,
+        check_free_memory=False,
+        **kwargs
     ):  # pylint: disable=unused-argument
         """ Initializes the daemon's internal data. """
         self.scan_collection = ScanCollection()
@@ -128,6 +133,7 @@ class OSPDaemon:
         self.initialized = None  # Set after initialization finished
 
         self.max_scans = max_scans
+        self.check_free_memory = check_free_memory
 
         self.scaninfo_store_time = kwargs.get('scaninfo_store_time')
 

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -18,6 +18,7 @@
 import argparse
 import logging
 from pathlib import Path
+from typing import Union
 
 from ospd.config import Config
 
@@ -165,6 +166,14 @@ class CliParser:
             help='Max. amount of parallel task that can be started. '
             'Default %(default)s, disabled',
         )
+        parser.add_argument(
+            '--check-free-memory',
+            default=False,
+            type=self.str2bool,
+            help='Check if there is enough free memory to run the scan. '
+            'This is an experimental feature. '
+            'Default %(default)s, disabled',
+        )
 
         self.parser = parser
 
@@ -177,6 +186,14 @@ class CliParser:
                 'port must be in ]0,65535] interval'
             )
         return value
+
+    def str2bool(self, value: Union[int, str, bool]) -> bool:
+        """ Check if provided string is a valid bool value. """
+        if isinstance(value, bool):
+            return value
+        if value.lower() in ('yes', 'true', 't', 'y', '1'):
+            return True
+        return False
 
     def log_level(self, string: str) -> int:
         """ Check if provided string is a valid log level. """

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -36,6 +36,7 @@ DEFAULT_PID_PATH = "/var/run/ospd.pid"
 DEFAULT_LOCKFILE_DIR_PATH = "/var/run/ospd"
 DEFAULT_STREAM_TIMEOUT = 10  # ten seconds
 DEFAULT_SCANINFO_STORE_TIME = 0  # in hours
+DEFAULT_MAX_SCAN = 0  # 0 = disable
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -156,6 +157,13 @@ class CliParser:
             '--list-commands',
             action='store_true',
             help='Display all protocol commands',
+        )
+        parser.add_argument(
+            '--max-scans',
+            default=DEFAULT_MAX_SCAN,
+            type=int,
+            help='Max. amount of parallel task that can be started. '
+            'Default %(default)s, disabled',
         )
 
         self.parser = parser

--- a/tests/command/test_commands.py
+++ b/tests/command/test_commands.py
@@ -128,6 +128,24 @@ class StartScanTestCase(TestCase):
 
         assert_called(mock_create_process)
 
+    def test_is_new_scan_allowed_false(self):
+        daemon = DummyWrapper([])
+        cmd = StartScan(daemon)
+
+        cmd._daemon.scan_processes = {'a': 1, 'b': 2}
+        daemon.max_scans = 1
+
+        self.assertFalse(cmd.is_new_scan_allowed())
+
+    def test_is_new_scan_allowed_true(self):
+        daemon = DummyWrapper([])
+        cmd = StartScan(daemon)
+
+        cmd._daemon.scan_processes = {'a': 1, 'b': 2}
+        daemon.max_scans = 3
+
+        self.assertTrue(cmd.is_new_scan_allowed())
+
     @patch("ospd.command.command.create_process")
     def test_scan_without_vts(self, mock_create_process):
         daemon = DummyWrapper([])


### PR DESCRIPTION
Add max_scans cmd option and check if was already reached before starting a new scan.
Add check_free_memory cmd option and check if there is enough free memory before starting a scan.
The options are independent of each other and can be combined .
The memory check is experimental and must be improved.
At the moment the start scan will be rejected.