### PR TITLE
Receive storage type argument at init.

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -320,7 +320,7 @@ class GetVts(BaseCommand):
 
         vt_details = False if _details == '0' else True
 
-        if vt_id and vt_id not in self._daemon.vts:
+        if self._daemon.vts and vt_id and vt_id not in self._daemon.vts:
             text = "Failed to find vulnerability test '{0}'".format(vt_id)
             raise OspdCommandError(text, 'get_vts', 404)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -110,6 +110,7 @@ class OSPDaemon:
         self,
         *,
         customvtfilter=None,
+        storage=None,
         max_scans=0,
         check_free_memory=False,
         **kwargs
@@ -150,7 +151,7 @@ class OSPDaemon:
         for name, params in BASE_SCANNER_PARAMS.items():
             self.set_scanner_param(name, params)
 
-        self.vts = Vts()
+        self.vts = Vts(storage)
         self.vts_version = None
 
         if customvtfilter:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1093,8 +1093,6 @@ class OSPDaemon:
             List of selected VT's OID.
         """
         vts_xml = []
-        if not self.vts:
-            return vts_xml
 
         # No match for the filter
         if filtered_vts is not None and len(filtered_vts) == 0:


### PR DESCRIPTION
These changes make ospd independent of a VT cache. Important for those scanner wrappers which does not need a cache or even not have plugin set.