### PR TITLE
Add initialized flag. If active, don't response to get_vts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add clean_forgotten_scans(). [#171](https://github.com/greenbone/ospd/pull/171)
 - Extend OSP with finished_hosts to improve resume task.  [#177](https://github.com/greenbone/ospd/pull/177)
 - Add lock-file-dir configuration option. [#217](https://github.com/greenbone/ospd/pull/217)
+- Add initialized flag. [#256](https://github.com/greenbone/ospd/pull/256)
 
 ### Changed
 - Set loglevel to debug for some message. [#159](https://github.com/greenbone/ospd/pull/159)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -214,11 +214,14 @@ class OSPDaemon:
         else:
             self.vts_filter = VtsFilter()
 
+        self.initialized = False
+
     def init(self):
         """ Should be overridden by a subclass if the initialization is costly.
 
             Will be called before check.
         """
+        self.initialized = True
 
     def set_command_attributes(self, name, attributes):
         """ Sets the xml attributes of a specified command. """
@@ -1037,6 +1040,11 @@ class OSPDaemon:
 
         @return: Response string for <get_vts> command.
         """
+        if not self.initialized:
+            return simple_response_str(
+                'get_vts', 200, 'OK', 'A vts update is being performed.'
+            )
+
         xml_helper = XmlStringHelper()
 
         vt_id = vt_et.attrib.get('vt_id')
@@ -1832,11 +1840,25 @@ class OSPDaemon:
         )
 
     def add_scan_error(
-            self, scan_id, host='', hostname='', name='', value='', port='', test_id=''
+        self,
+        scan_id,
+        host='',
+        hostname='',
+        name='',
+        value='',
+        port='',
+        test_id='',
     ):
         """ Adds an error result to scan_id scan. """
         self.scan_collection.add_result(
-            scan_id, ResultType.ERROR, host, hostname, name, value, port, test_id
+            scan_id,
+            ResultType.ERROR,
+            host,
+            hostname,
+            name,
+            value,
+            port,
+            test_id,
         )
 
     def add_scan_host_detail(

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -69,6 +69,7 @@ class DummyWrapper(OSPDaemon):
         super().__init__()
         self.checkresult = checkresult
         self.results = results
+        self.initialized = True
 
     def check(self):
         return self.checkresult


### PR DESCRIPTION
Instead return an error. This is to avoid a client receive a malformed
vt collection during a vt upload.


Black modified some methods automatically.