### PR TITLE
Add flag to advice that the cache is being used for a process.

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -323,14 +323,20 @@ class GetVts(BaseCommand):
         vt_details = False if _details == '0' else True
 
         if self._daemon.vts and vt_id and vt_id not in self._daemon.vts:
+            self._daemon.vts.is_cache_available = True
             text = "Failed to find vulnerability test '{0}'".format(vt_id)
             raise OspdCommandError(text, 'get_vts', 404)
 
         filtered_vts = None
         if vt_filter:
-            filtered_vts = self._daemon.vts_filter.get_filtered_vts_list(
-                self._daemon.vts, vt_filter
-            )
+            try:
+                filtered_vts = self._daemon.vts_filter.get_filtered_vts_list(
+                    self._daemon.vts, vt_filter
+                )
+            except OspdCommandError as filter_error:
+                self._daemon.vts.is_cache_available = True
+                raise OspdCommandError(filter_error)
+
         vts_selection = self._daemon.get_vts_selection_list(vt_id, filtered_vts)
         # List of xml pieces with the generator to be iterated
         yield xml_helper.create_response('get_vts')

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -312,6 +312,8 @@ class GetVts(BaseCommand):
 
         @return: Response string for <get_vts> command on fail.
         """
+        self._daemon.vts.is_cache_available = False
+
         xml_helper = XmlStringHelper()
 
         vt_id = xml.get('vt_id')
@@ -352,6 +354,8 @@ class GetVts(BaseCommand):
 
         yield xml_helper.create_element('vts', end=True)
         yield xml_helper.create_response('get_vts', end=True)
+
+        self._daemon.vts.is_cache_available = True
 
 
 class StopScan(BaseCommand):

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -979,7 +979,7 @@ class OSPDaemon:
 
         @return: String of single vulnerability test information in XML format.
         """
-        if not single_vt:
+        if not single_vt or single_vt[1] is None:
             return Element('vt')
 
         vt_id, vt = single_vt

--- a/ospd/vts.py
+++ b/ospd/vts.py
@@ -49,6 +49,8 @@ class Vts:
         self._vts = None
         self.sha256_hash = None
 
+        self.is_cache_available = True
+
     def __contains__(self, key: str) -> bool:
         return key in self._vts
 


### PR DESCRIPTION
This allows to block the use of the cache by one process and avoid
other process to do an action on the cache.
Eg. update vts cache during response of get_vts cmd.