### PR TITLE
Improve handling of dead hosts and improve scan progress calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add details attribute to get_vts command. [#222](https://github.com/greenbone/ospd/pull/222)
 - Add [pontos](https://github.com/greenbone/pontos) as dev dependency for
   managing the version information in ospd [#254](https://github.com/greenbone/ospd/pull/254)
+- Add more info about scan progress with progress attribute in get_scans cmd. [#266](https://github.com/greenbone/ospd/pull/266)
 
 ### Changes
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)
@@ -30,10 +31,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   a bit different then `pipenv install`. It installs dev packages by default and
   also ospd in editable mode. This means after running poetry install ospd will
   directly be importable in the virtual python environment. [#252](https://github.com/greenbone/ospd/pull/252)
+- Progress bar calculation does not take in account the dead hosts. [#266](https://github.com/greenbone/ospd/pull/266)
 
 ### Fixed
 - Fix stop scan. Wait for the scan process to be stopped before delete it from the process table. [#204](https://github.com/greenbone/ospd/pull/204)
 - Fix get_scanner_details(). [#210](https://github.com/greenbone/ospd/pull/210)
+
+### Removed
+- Remove support for resume task. [#266](https://github.com/greenbone/ospd/pull/266)
 
 ## [2.0.1] (unreleased)
 

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -208,7 +208,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>finished_hosts</name>
-      <summary>One or many finished hosts to exclude when resuming a task. The list is comma-separated. Each entry can be an IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. The listed hosts will be set as finished before starting the scan. Each wrapper must handle the finished hosts.
+      <summary>One or many finished hosts to exclude when the client resumes a task. The list is comma-separated. Each entry can be an IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. The listed hosts will be set as finished before starting the scan. Each wrapper must handle the finished hosts.
       </summary>
       <type>string</type>
     </ele>
@@ -440,6 +440,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
             <attributes>
               <scan_id>ID of a specific scan to get</scan_id>
               <details>Whether to return the full scan report</details>
+              <progress>Whether to return a detailed progress information</progress>
               <pop_results>Whether to remove the fetched results</pop_results>
               <max_results>Maximum number of results to fetch. Only considered if pop_results is enabled. Default = None, which means that all available results are returned</max_results>
             </attributes>
@@ -519,6 +520,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <attrib>
         <name>details</name>
         <summary>Whether to get full scan reports</summary>
+        <type>boolean</type>
+      </attrib>
+      <attrib>
+        <name>progress</name>
+        <summary>Whether to return a detailed progress information</summary>
         <type>boolean</type>
       </attrib>
       <attrib>
@@ -621,6 +627,30 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
                </result>
              </results>
            </scan>
+        </get_scans_response>
+      </response>
+    </example>
+    <example>
+      <summary>Get a scan progress summary</summary>
+      <request>
+        <get_scans scan_id="f14747d3-a4d7-4e79-99bb-a0a1276cb78c" details="0" progress="1"/>
+      </request>
+      <response>
+        <get_scans_response status_text="OK" status="200">
+          <scan id="9750f1f8-07aa-49cc-9c31-2f9e469c8f65" target="192.168.1.252"
+                end_time="1432824234" progress="100" status="finished" start_time="1432824206">
+            <progress>
+              <host name="192.168.0.176">0.0</host>
+              <host name="192.168.0.77">68.00013854253257</host>
+              <host name="192.168.0.148">26.0009697977279</host>
+              <host name="192.168.0.1">0.0</host>
+              <overall>38.800221668052096</overall>
+              <count_alive>1</count_alive>
+              <count_dead>249</count_dead>
+              <count_excluded>0</count_excluded>
+              <count_total>254</count_total>
+            </progress>
+          </scan>
         </get_scans_response>
       </response>
     </example>

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -418,17 +418,12 @@ class GetScans(BaseCommand):
             details = False
         else:
             details = True
-            if pop_res and pop_res == '1':
-                pop_res = True
-            else:
-                pop_res = False
+            pop_res = pop_res and pop_res == '1'
+
             if max_res:
                 max_res = int(max_res)
 
-        if progress and progress == '1':
-            progress = True
-        else:
-            progress = False
+        progress = progress and progress == '1'
 
         responses = []
         if scan_id and scan_id in self._daemon.scan_collection.ids_iterator():

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -412,6 +412,7 @@ class GetScans(BaseCommand):
         details = xml.get('details')
         pop_res = xml.get('pop_results')
         max_res = xml.get('max_results')
+        progress = xml.get('progress')
 
         if details and details == '0':
             details = False
@@ -424,10 +425,17 @@ class GetScans(BaseCommand):
             if max_res:
                 max_res = int(max_res)
 
+        if progress and progress == '1':
+            progress = True
+        else:
+            progress = False
+
         responses = []
         if scan_id and scan_id in self._daemon.scan_collection.ids_iterator():
             self._daemon.check_scan_process(scan_id)
-            scan = self._daemon.get_scan_xml(scan_id, details, pop_res, max_res)
+            scan = self._daemon.get_scan_xml(
+                scan_id, details, pop_res, max_res, progress
+            )
             responses.append(scan)
         elif scan_id:
             text = "Failed to find scan '{0}'".format(scan_id)
@@ -436,7 +444,7 @@ class GetScans(BaseCommand):
             for scan_id in self._daemon.scan_collection.ids_iterator():
                 self._daemon.check_scan_process(scan_id)
                 scan = self._daemon.get_scan_xml(
-                    scan_id, details, pop_res, max_res
+                    scan_id, details, pop_res, max_res, progress
                 )
                 responses.append(scan)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -56,6 +56,7 @@ from ospd.vts import Vts
 from ospd.xml import (
     elements_as_text,
     get_result_xml,
+    get_progress_xml,
     get_elements_from_dict,
 )
 
@@ -700,6 +701,32 @@ class OSPDaemon:
         logger.debug('Returning %d results', len(results))
         return results
 
+    def get_scan_progress_xml(self, scan_id: str):
+        """ Gets scan_id scan's progress in XML format.
+
+        @return: String of scan progress in xml.
+        """
+        current_progress = dict()
+
+        current_progress[
+            'current_hosts'
+        ] = self.scan_collection.get_current_target_progress(scan_id)
+        current_progress['overall'] = self.scan_collection.get_progress(scan_id)
+        current_progress['count_alive'] = self.scan_collection.get_count_alive(
+            scan_id
+        )
+        current_progress['count_dead'] = self.scan_collection.get_count_dead(
+            scan_id
+        )
+        current_progress[
+            'count_excluded'
+        ] = self.scan_collection.simplify_exclude_host_count(scan_id)
+        current_progress['count_total'] = self.scan_collection.get_host_count(
+            scan_id
+        )
+
+        return get_progress_xml(current_progress)
+
     @deprecated(
         version="20.8",
         reason="Please use ospd.xml.get_elements_from_dict instead.",
@@ -719,6 +746,7 @@ class OSPDaemon:
         detailed: bool = True,
         pop_res: bool = False,
         max_res: int = 0,
+        progress: bool = False,
     ):
         """ Gets scan in XML format.
 
@@ -746,6 +774,9 @@ class OSPDaemon:
             response.append(
                 self.get_scan_results_xml(scan_id, pop_res, max_res)
             )
+        if progress:
+            response.append(self.get_scan_progress_xml(scan_id))
+
         return response
 
     @staticmethod

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -509,7 +509,6 @@ class OSPDaemon:
     def process_finished_hosts(self, scan_id: str, finished_hosts: str) -> None:
         """ Process the finished hosts before launching the scans."""
 
-        exc_hosts_list = ''
         if not finished_hosts:
             return
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -505,29 +505,15 @@ class OSPDaemon:
 
         return self.scan_collection.calculate_target_progress(scan_id)
 
-    def process_exclude_hosts(self, scan_id: str, exclude_hosts: str) -> None:
-        """ Process the exclude hosts before launching the scans."""
-
-        exc_hosts_list = ''
-        if not exclude_hosts:
-            return
-        exc_hosts_list = target_str_to_list(exclude_hosts)
-        self.remove_scan_hosts_from_target_progress(scan_id, exc_hosts_list)
-
     def process_finished_hosts(self, scan_id: str, finished_hosts: str) -> None:
-        """ Process the finished hosts before launching the scans.
-        Set finished hosts as finished with 100% to calculate
-        the scan progress."""
+        """ Process the finished hosts before launching the scans."""
 
         exc_hosts_list = ''
         if not finished_hosts:
             return
 
-        exc_hosts_list = target_str_to_list(finished_hosts)
-
-        for host in exc_hosts_list:
-            self.set_scan_host_finished(scan_id, finished_hosts=host)
-            self.set_scan_host_progress(scan_id, host=host, progress=100)
+        exc_finished_hosts_list = target_str_to_list(finished_hosts)
+        self.scan_collection.set_host_finished(scan_id, exc_finished_hosts_list)
 
     def start_scan(self, scan_id: str, target: Dict) -> None:
         """ Starts the scan with scan_id. """
@@ -538,7 +524,6 @@ class OSPDaemon:
 
         logger.info("%s: Scan started.", scan_id)
 
-        self.process_exclude_hosts(scan_id, target.get('exclude_hosts'))
         self.process_finished_hosts(scan_id, target.get('finished_hosts'))
 
         try:
@@ -1280,14 +1265,6 @@ class OSPDaemon:
     def get_scan_vts(self, scan_id: str) -> Dict:
         """ Gives a scan's vts. """
         return self.scan_collection.get_vts(scan_id)
-
-    def get_scan_unfinished_hosts(self, scan_id: str) -> List:
-        """ Get a list of unfinished hosts."""
-        return self.scan_collection.get_hosts_unfinished(scan_id)
-
-    def get_scan_finished_hosts(self, scan_id: str) -> List:
-        """ Get a list of unfinished hosts."""
-        return self.scan_collection.get_hosts_finished(scan_id)
 
     def get_scan_start_time(self, scan_id: str) -> str:
         """ Gives a scan's start time. """

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -703,7 +703,7 @@ class OSPDaemon:
         logger.debug('Returning %d results', len(results))
         return results
 
-    def get_scan_progress_xml(self, scan_id: str):
+    def _get_scan_progress_xml(self, scan_id: str):
         """ Gets scan_id scan's progress in XML format.
 
         @return: String of scan progress in xml.
@@ -777,7 +777,7 @@ class OSPDaemon:
                 self.get_scan_results_xml(scan_id, pop_res, max_res)
             )
         if progress:
-            response.append(self.get_scan_progress_xml(scan_id))
+            response.append(self._get_scan_progress_xml(scan_id))
 
         return response
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1198,23 +1198,17 @@ class OSPDaemon:
         @target: Target to scan.
         @options: Miscellaneous scan options.
 
-        @return: New scan's ID. None if the scan_id already exists and the
-                 scan status is RUNNING or FINISHED.
+        @return: New scan's ID. None if the scan_id already exists.
         """
         status = None
         scan_exists = self.scan_exists(scan_id)
         if scan_id and scan_exists:
             status = self.get_scan_status(scan_id)
-
-        if scan_exists and status == ScanStatus.STOPPED:
-            logger.info("Scan %s exists. Resuming scan.", scan_id)
-        elif scan_exists and (
-            status == ScanStatus.RUNNING or status == ScanStatus.FINISHED
-        ):
             logger.info(
                 "Scan %s exists with status %s.", scan_id, status.name.lower()
             )
             return
+
         return self.scan_collection.create_scan(
             scan_id, targets, options, vt_selection
         )

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -196,50 +196,6 @@ class ScanCollection:
 
         return iter(self.scans_table.keys())
 
-    def remove_single_result(
-        self, scan_id: str, result: Dict[str, str]
-    ) -> None:
-        """Removes a single result from the result list in scan_table.
-
-        Parameters:
-            scan_id (uuid): Scan ID to identify the scan process to be resumed.
-            result (dict): The result to be removed from the results list.
-        """
-        results = self.scans_table[scan_id]['results']
-        results.remove(result)
-        self.scans_table[scan_id]['results'] = results
-
-    def del_results_for_stopped_hosts(self, scan_id: str) -> None:
-        """ Remove results from the result table for those host
-        """
-        unfinished_hosts = self.get_hosts_unfinished(scan_id)
-        for result in self.results_iterator(
-            scan_id, pop_res=False, max_res=None
-        ):
-            if result['host'] in unfinished_hosts:
-                self.remove_single_result(scan_id, result)
-
-    def resume_scan(self, scan_id: str, options: Optional[Dict]) -> str:
-        """ Reset the scan status in the scan_table to INIT.
-        Also, overwrite the options, because a resume task cmd
-        can add some new option. E.g. exclude hosts list.
-        Parameters:
-            scan_id (uuid): Scan ID to identify the scan process to be resumed.
-            options (dict): Options for the scan to be resumed. This options
-                            are not added to the already existent ones.
-                            The old ones are removed
-
-        Return:
-            Scan ID which identifies the current scan.
-        """
-        self.scans_table[scan_id]['status'] = ScanStatus.INIT
-        if options:
-            self.scans_table[scan_id]['options'] = options
-
-        self.del_results_for_stopped_hosts(scan_id)
-
-        return scan_id
-
     def create_scan(
         self,
         scan_id: str = '',

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -348,15 +348,15 @@ class ScanCollection:
         The value is calculated with the progress of each single host
         in the target."""
 
-        host = self.get_host_list(scan_id)
-        total_hosts = len(target_str_to_list(host))
-        exc_hosts_list = self.simplify_exclude_host_list(scan_id)
-        exc_hosts = len(exc_hosts_list) if exc_hosts_list else 0
+        total_hosts = self.get_host_count(scan_id)
+        exc_hosts = self.simplify_exclude_host_count(scan_id)
+        count_alive = self.get_count_alive(scan_id)
+        count_dead = self.get_count_dead(scan_id)
         host_progresses = self.scans_table[scan_id].get('target_progress')
 
         try:
-            t_prog = sum(host_progresses.values()) / (
-                total_hosts - exc_hosts
+            t_prog = (sum(host_progresses.values()) + 100 * count_alive) / (
+                total_hosts - exc_hosts - count_dead
             )  # type: float
         except ZeroDivisionError:
             LOGGER.error(

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -305,11 +305,29 @@ class ScanCollection:
 
         return self.scans_table[scan_id]['progress']
 
-    def simplify_exclude_host_list(self, scan_id: str) -> List[Any]:
+    def get_count_dead(self, scan_id: str) -> int:
+        """ Get a scan's current dead host count. """
+
+        return self.scans_table[scan_id]['count_dead']
+
+    def get_count_alive(self, scan_id: str) -> int:
+        """ Get a scan's current dead host count. """
+
+        return self.scans_table[scan_id]['count_alive']
+
+    def get_current_target_progress(self, scan_id: str) -> Dict[str, int]:
+        """ Get a scan's current dead host count. """
+
+        return self.scans_table[scan_id]['target_progress']
+
+    def simplify_exclude_host_count(self, scan_id: str) -> int:
         """ Remove from exclude_hosts the received hosts in the finished_hosts
         list sent by the client.
         The finished hosts are sent also as exclude hosts for backward
         compatibility purposses.
+
+        Return:
+            Count of excluded host.
         """
 
         exc_hosts_list = target_str_to_list(self.get_exclude_hosts(scan_id))
@@ -323,7 +341,7 @@ class ScanCollection:
                 if finished in exc_hosts_list:
                     exc_hosts_list.remove(finished)
 
-        return exc_hosts_list
+        return len(exc_hosts_list) if exc_hosts_list else 0
 
     def calculate_target_progress(self, scan_id: str) -> float:
         """ Get a target's current progress value.
@@ -363,6 +381,13 @@ class ScanCollection:
         """ Get a scan's host list. """
 
         return self.scans_table[scan_id]['target'].get('hosts')
+
+    def get_host_count(self, scan_id: str) -> int:
+        """ Get total host count in the target. """
+        host = self.get_host_list(scan_id)
+        total_hosts = len(target_str_to_list(host))
+
+        return total_hosts
 
     def get_ports(self, scan_id: str):
         """ Get a scan's ports list.

--- a/ospd/xml.py
+++ b/ospd/xml.py
@@ -99,6 +99,32 @@ def get_result_xml(result):
     return result_xml
 
 
+def get_progress_xml(progress: Dict[str, int]):
+    """ Formats a scan progress to XML format.
+
+    Arguments:
+        progress (dict): Dictionary with a scan progress.
+
+    Return:
+        Progress as xml element object.
+    """
+
+    progress_xml = Element('progress')
+    for progress_item, value in progress.items():
+        elem = None
+        if progress_item == 'current_hosts':
+            for host, h_progress in value.items():
+                elem = Element('host')
+                elem.set('name', host)
+                elem.text = str(h_progress)
+                progress_xml.append(elem)
+        else:
+            elem = Element(progress_item)
+            elem.text = str(value)
+            progress_xml.append(elem)
+    return progress_xml
+
+
 def simple_response_str(
     command: str,
     status: int,


### PR DESCRIPTION
Dead host can be set directly as dead, or can be recognized as dead if the scan progress is -1

The list of finished hosts is not kept anymore, and therefore support for resume task is removed.

Only the amount of finished  hosts (alive or dead) are stored and the scan progress calculation has been changed. The dead host are not taken in account for calculation.

A new attribute "progress" is added for <get_scans> to get more information about the scan progress. Per default is disabled. 
Usage example:

```<get_scans details='0' progress='1'/>```