### PR TITLE
Use daemon mode for python 3.7

### DIFF
--- a/ospd/server.py
+++ b/ospd/server.py
@@ -178,15 +178,13 @@ class SocketServerMixin:
 
 
 class ThreadedUnixSocketServer(
-    SocketServerMixin,
-    socketserver.ThreadingMixIn,
-    socketserver.UnixStreamServer,
+    SocketServerMixin, socketserver.ThreadingUnixStreamServer,
 ):
     pass
 
 
 class ThreadedTlsSocketServer(
-    SocketServerMixin, socketserver.ThreadingMixIn, socketserver.TCPServer
+    SocketServerMixin, socketserver.ThreadingTCPServer,
 ):
     pass
 

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -158,6 +158,17 @@ class BaseServer(ABC):
 
 
 class SocketServerMixin:
+    # Use daemon mode to circrumvent a memory leak
+    # (reported at https://bugs.python.org/issue37193).
+    #
+    # Daemonic threads are killed immediately by the python interpreter without
+    # waiting for until they are finished.
+    #
+    # Maybe block_on_close = True could work too.
+    # In that case the interpreter waits for the threads to finish but doesn't
+    # track them in the _threads list.
+    daemon_threads = True
+
     def __init__(self, server: BaseServer, address: Union[str, InetAddress]):
         self.server = server
         super().__init__(address, RequestHandler, bind_and_activate=True)


### PR DESCRIPTION
Use daemon mode to circrumvent a memory leak (reported at https://bugs.python.org/issue37193).

Daemonic threads are killed immediately on shutdown by the python interpreter without waiting for until they are finished.

Maybe block_on_close = True could work too. In that case the interpreter waits for the threads to finish but doesn't track them in the _threads list.

It seems that the interpreter always waits for non-daemonic threads before finishing. Therefore I currently wonder why the Python devs added thread joining to the ThreadingMixIn (https://github.com/python/cpython/blob/3.7/Lib/socketserver.py#L674) at all when it is done on shutdown automatically already.

Short example script (works with Python 2.7 too) for playing with the different threading behavior.
```python
from __future__ import print_function

import time

from threading import Thread


def run():

    for i in range(1, 10):
        print("I am the daemon thread. I keep on running bg...%i" % (i,))

        time.sleep(2)


if __name__ == "__main__":
    # Main thread

    thread = Thread(target=run)
   
    # play with daemonic and non-daemonic threads
    #  thread.daemon = True
    thread.daemon = False

    thread.start()

    print("My Daemon will take care")

    time.sleep(10)
    print('Exiting')
    
    # play with join
    # thread.join()
```

