### PR TITLE
Ignore subsequent SIGINT once inside exit_cleanup()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Progress bar calculation does not take in account the dead hosts. [#266](https://github.com/greenbone/ospd/pull/266)
 - Show progress as integer for get_scans. [#269](https://github.com/greenbone/ospd/pull/269)
 - Make scan_id attribute mandatory for get_scans. [#270](https://github.com/greenbone/ospd/pull/270)
+- Ignore subsequent SIGINT once inside exit_cleanup(). [#273](https://github.com/greenbone/ospd/pull/273)
 
 ### Fixed
 - Fix stop scan. Wait for the scan process to be stopped before delete it from the process table. [#204](https://github.com/greenbone/ospd/pull/204)
 - Fix get_scanner_details(). [#210](https://github.com/greenbone/ospd/pull/210)
+- Fix thread lib leak using daemon mode for python 3.7. [#272](https://github.com/greenbone/ospd/pull/272)
 
 ### Removed
 - Remove support for resume task. [#266](https://github.com/greenbone/ospd/pull/266)

--- a/ospd/main.py
+++ b/ospd/main.py
@@ -110,6 +110,7 @@ def exit_cleanup(
     pidfile: str, server: BaseServer, _signum=None, _frame=None
 ) -> None:
     """ Removes the pidfile before ending the daemon. """
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     pidpath = Path(pidfile)
 
     if not pidpath.is_file():


### PR DESCRIPTION
This avoid to leave the pid file because interruptions during the
cleanup, especially when the --foreground mode is enabled and the user
tries to kill ospd-openvas many times with ctrl+c