### PR TITLE
Create a pre fork()'ed data manager to store scan data information

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -574,11 +574,10 @@ class StartScan(BaseCommand):
                 vt_selection = OspRequest.process_vts_params(scanner_vts)
 
         # Dry run case.
-        if 'dry_run' in params and int(params['dry_run']):
-            scan_func = self._daemon.dry_run_scan
+        dry_run = 'dry_run' in params and int(params['dry_run'])
+        if dry_run:
             scan_params = None
         else:
-            scan_func = self._daemon.start_scan
             scan_params = self._daemon.process_scan_params(params)
 
         scan_id_aux = scan_id
@@ -591,13 +590,13 @@ class StartScan(BaseCommand):
             id_.text = scan_id_aux
             return simple_response_str('start_scan', 100, 'Continue', id_)
 
-        scan_process = create_process(
-            func=scan_func, args=(scan_id, scan_target)
-        )
-
-        self._daemon.scan_processes[scan_id] = scan_process
-
-        scan_process.start()
+        if dry_run:
+            scan_func = self._daemon.dry_run_scan
+            scan_process = create_process(
+                func=scan_func, args=(scan_id, scan_target)
+            )
+            self._daemon.scan_processes[scan_id] = scan_process
+            scan_process.start()
 
         id_ = Element('id')
         id_.text = scan_id

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -168,7 +168,7 @@ class OSPDaemon:
 
             Will be called after check.
         """
-        self.scan_collection.init_data_manager()
+        self.scan_collection.init()
         server.start(self.handle_client_stream)
         self.initialized = True
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1187,7 +1187,7 @@ class OSPDaemon:
             logger.info("Received Ctrl-C shutting-down ...")
 
     def check_pending_scans(self):
-        for scan_id in list(self.scan_collection.ids_iterator()):
+        for scan_id in self.scan_collection.ids_iterator():
             if self.get_scan_status(scan_id) == ScanStatus.PENDING:
                 scan_target = self.scan_collection.scans_table[scan_id].get(
                     'target'

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -547,7 +547,7 @@ class OSPDaemon:
 
         os.setsid()
 
-        host = resolve_hostname(target[0])
+        host = resolve_hostname(target.get('hosts'))
         if host is None:
             logger.info("Couldn't resolve %s.", self.get_scan_host(scan_id))
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1272,8 +1272,11 @@ class OSPDaemon:
 
     def check_scan_process(self, scan_id: str) -> None:
         """ Check the scan's process, and terminate the scan if not alive. """
-        scan_process = self.scan_processes[scan_id]
+        scan_process = self.scan_processes.get(scan_id)
         progress = self.get_scan_progress(scan_id)
+
+        if self.get_scan_status(scan_id) == ScanStatus.PENDING:
+            return
 
         if progress < PROGRESS_FINISHED and not scan_process.is_alive():
             if not self.get_scan_status(scan_id) == ScanStatus.STOPPED:

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1181,12 +1181,12 @@ class OSPDaemon:
                 time.sleep(SCHEDULER_CHECK_PERIOD)
                 self.scheduler()
                 self.clean_forgotten_scans()
-                self.check_pending_scans()
+                self.start_pending_scans()
                 self.wait_for_children()
         except KeyboardInterrupt:
             logger.info("Received Ctrl-C shutting-down ...")
 
-    def check_pending_scans(self):
+    def start_pending_scans(self):
         for scan_id in self.scan_collection.ids_iterator():
             if self.get_scan_status(scan_id) == ScanStatus.PENDING:
                 scan_target = self.scan_collection.scans_table[scan_id].get(

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1174,6 +1174,8 @@ class OSPDaemon:
         """ Starts the Daemon, handling commands until interrupted.
         """
 
+        self.scan_collection.data_manager = multiprocessing.Manager()
+
         try:
             while True:
                 time.sleep(SCHEDULER_CHECK_PERIOD)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -168,6 +168,7 @@ class OSPDaemon:
 
             Will be called after check.
         """
+        self.scan_collection.init_data_manager()
         server.start(self.handle_client_stream)
         self.initialized = True
 
@@ -1173,8 +1174,6 @@ class OSPDaemon:
     def run(self) -> None:
         """ Starts the Daemon, handling commands until interrupted.
         """
-
-        self.scan_collection.data_manager = multiprocessing.Manager()
 
         try:
             while True:

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -377,15 +377,11 @@ class ScanCollection:
 
     def get_vts(self, scan_id: str) -> Dict:
         """ Get a scan's vts. """
+        scan_info = self.scans_table[scan_id]
+        vts = scan_info.pop('vts')
+        self.scans_table[scan_id] = scan_info
 
-        return self.scans_table[scan_id]['vts']
-
-    def release_vts_list(self, scan_id: str) -> None:
-        """ Release the memory used for the vts list. """
-
-        scan_data = self.scans_table.get(scan_id)
-        if scan_data and 'vts' in scan_data:
-            del scan_data['vts']
+        return vts
 
     def id_exists(self, scan_id: str) -> bool:
         """ Check whether a scan exists in the table. """

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -347,7 +347,10 @@ class ScanCollection:
     def get_ports(self, scan_id: str):
         """ Get a scan's ports list.
         """
-        return self.scans_table[scan_id]['target'].get('ports')
+        target = self.scans_table[scan_id].get('target')
+        ports = target.pop('ports')
+        self.scans_table[scan_id]['target'] = target
+        return ports
 
     def get_exclude_hosts(self, scan_id: str):
         """ Get an exclude host list for a given target.

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -32,10 +32,11 @@ LOGGER = logging.getLogger(__name__)
 class ScanStatus(Enum):
     """Scan status. """
 
-    INIT = 0
-    RUNNING = 1
-    STOPPED = 2
-    FINISHED = 3
+    PENDING = 0
+    INIT = 1
+    RUNNING = 2
+    STOPPED = 3
+    FINISHED = 4
 
 
 class ScanCollection:

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -224,7 +224,7 @@ class ScanCollection:
         scan_info['options'] = options
         scan_info['start_time'] = int(time.time())
         scan_info['end_time'] = 0
-        scan_info['status'] = ScanStatus.INIT
+        scan_info['status'] = ScanStatus.PENDING
 
         if scan_id is None or scan_id == '':
             scan_id = str(uuid.uuid4())

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -209,9 +209,6 @@ class ScanCollection:
         if not target:
             target = {}
 
-        if self.data_manager is None:
-            self.data_manager = multiprocessing.Manager()
-
         if not options:
             options = dict()
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -64,7 +64,7 @@ class ScanCollection:
         )  # type: Optional[multiprocessing.managers.SyncManager]
         self.scans_table = dict()  # type: Dict
 
-    def init_data_manager(self):
+    def init(self):
         self.data_manager = multiprocessing.Manager()
 
     def add_result(

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -64,6 +64,9 @@ class ScanCollection:
         )  # type: Optional[multiprocessing.managers.SyncManager]
         self.scans_table = dict()  # type: Dict
 
+    def init_data_manager(self):
+        self.data_manager = multiprocessing.Manager()
+
     def add_result(
         self,
         scan_id: str,

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -394,10 +394,8 @@ class ScanCollection:
         if self.get_status(scan_id) == ScanStatus.RUNNING:
             return False
 
-        self.scans_table.pop(scan_id)
-
-        if len(self.scans_table) == 0:
-            del self.data_manager
-            self.data_manager = None
+        scans_table = self.scans_table
+        del scans_table[scan_id]
+        self.scans_table = scans_table
 
         return True

--- a/tests/command/test_commands.py
+++ b/tests/command/test_commands.py
@@ -31,7 +31,7 @@ from ospd.command.command import (
 from ospd.errors import OspdCommandError, OspdError
 from ospd.misc import create_process
 
-from ..helper import DummyWrapper, assert_called, FakeStream
+from ..helper import DummyWrapper, assert_called, FakeStream, FakeDataManager
 
 
 class GetPerformanceTestCase(TestCase):
@@ -97,7 +97,7 @@ class StartScanTestCase(TestCase):
         with self.assertRaises(OspdCommandError):
             cmd.handle_xml(request)
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     def test_scan_with_vts(self, mock_create_process):
         daemon = DummyWrapper([])
         cmd = StartScan(daemon)
@@ -121,12 +121,66 @@ class StartScanTestCase(TestCase):
         response = et.fromstring(cmd.handle_xml(request))
         scan_id = response.findtext('id')
 
-        self.assertEqual(
-            daemon.get_scan_vts(scan_id), {'1.2.3.4': {}, 'vt_groups': []}
-        )
-        self.assertNotEqual(daemon.get_scan_vts(scan_id), {'1.2.3.6': {}})
+        vts_collection = daemon.get_scan_vts(scan_id)
+        self.assertEqual(vts_collection, {'1.2.3.4': {}, 'vt_groups': []})
+        self.assertNotEqual(vts_collection, {'1.2.3.6': {}})
 
+        daemon.check_pending_scans()
         assert_called(mock_create_process)
+
+    def test_scan_pop_vts(self):
+        daemon = DummyWrapper([])
+        cmd = StartScan(daemon)
+
+        request = et.fromstring(
+            '<start_scan>'
+            '<targets>'
+            '<target>'
+            '<hosts>localhost</hosts>'
+            '<ports>80, 443</ports>'
+            '</target>'
+            '</targets>'
+            '<scanner_params />'
+            '<vt_selection>'
+            '<vt_single id="1.2.3.4" />'
+            '</vt_selection>'
+            '</start_scan>'
+        )
+
+        # With one vt, without params
+        response = et.fromstring(cmd.handle_xml(request))
+        scan_id = response.findtext('id')
+
+        vts_collection = daemon.get_scan_vts(scan_id)
+        self.assertEqual(vts_collection, {'1.2.3.4': {}, 'vt_groups': []})
+        self.assertRaises(KeyError, daemon.get_scan_vts, scan_id)
+
+    def test_scan_pop_ports(self):
+        daemon = DummyWrapper([])
+        cmd = StartScan(daemon)
+
+        request = et.fromstring(
+            '<start_scan>'
+            '<targets>'
+            '<target>'
+            '<hosts>localhost</hosts>'
+            '<ports>80, 443</ports>'
+            '</target>'
+            '</targets>'
+            '<scanner_params />'
+            '<vt_selection>'
+            '<vt_single id="1.2.3.4" />'
+            '</vt_selection>'
+            '</start_scan>'
+        )
+
+        # With one vt, without params
+        response = et.fromstring(cmd.handle_xml(request))
+        scan_id = response.findtext('id')
+
+        ports = daemon.scan_collection.get_ports(scan_id)
+        self.assertEqual(ports, '80, 443')
+        self.assertRaises(KeyError, daemon.scan_collection.get_ports, scan_id)
 
     def test_is_new_scan_allowed_false(self):
         daemon = DummyWrapper([])
@@ -152,7 +206,7 @@ class StartScanTestCase(TestCase):
 
         self.assertTrue(cmd.is_new_scan_allowed())
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     def test_scan_without_vts(self, mock_create_process):
         daemon = DummyWrapper([])
         cmd = StartScan(daemon)
@@ -172,9 +226,9 @@ class StartScanTestCase(TestCase):
         response = et.fromstring(cmd.handle_xml(request))
 
         scan_id = response.findtext('id')
-
         self.assertEqual(daemon.get_scan_vts(scan_id), {})
 
+        daemon.check_pending_scans()
         assert_called(mock_create_process)
 
     def test_scan_with_vts_and_param_missing_vt_param_id(self):
@@ -200,7 +254,7 @@ class StartScanTestCase(TestCase):
         with self.assertRaises(OspdError):
             cmd.handle_xml(request)
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     def test_scan_with_vts_and_param(self, mock_create_process):
         daemon = DummyWrapper([])
         cmd = StartScan(daemon)
@@ -229,7 +283,7 @@ class StartScanTestCase(TestCase):
             daemon.get_scan_vts(scan_id),
             {'1234': {'ABC': '200'}, 'vt_groups': []},
         )
-
+        daemon.check_pending_scans()
         assert_called(mock_create_process)
 
     def test_scan_with_vts_and_param_missing_vt_group_filter(self):
@@ -253,7 +307,7 @@ class StartScanTestCase(TestCase):
         with self.assertRaises(OspdError):
             cmd.handle_xml(request)
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     def test_scan_with_vts_and_param_with_vt_group_filter(
         self, mock_create_process
     ):
@@ -280,9 +334,10 @@ class StartScanTestCase(TestCase):
 
         self.assertEqual(daemon.get_scan_vts(scan_id), {'vt_groups': ['a']})
 
+        daemon.check_pending_scans()
         assert_called(mock_create_process)
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     @patch("ospd.command.command.logger")
     def test_scan_ignore_multi_target(self, mock_logger, mock_create_process):
         daemon = DummyWrapper([])
@@ -300,16 +355,18 @@ class StartScanTestCase(TestCase):
         )
 
         cmd.handle_xml(request)
-
+        daemon.check_pending_scans()
         assert_called(mock_logger.warning)
         assert_called(mock_create_process)
 
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     @patch("ospd.command.command.logger")
     def test_scan_use_legacy_target_and_port(
         self, mock_logger, mock_create_process
     ):
         daemon = DummyWrapper([])
+        daemon.scan_collection.datamanager = FakeDataManager()
+
         cmd = StartScan(daemon)
         request = et.fromstring(
             '<start_scan target="localhost" ports="22">'
@@ -325,20 +382,22 @@ class StartScanTestCase(TestCase):
         self.assertEqual(daemon.get_scan_host(scan_id), 'localhost')
         self.assertEqual(daemon.get_scan_ports(scan_id), '22')
 
+        daemon.check_pending_scans()
+
         assert_called(mock_logger.warning)
         assert_called(mock_create_process)
 
 
 class StopCommandTestCase(TestCase):
     @patch("ospd.ospd.os")
-    @patch("ospd.command.command.create_process")
+    @patch("ospd.ospd.create_process")
     def test_stop_scan(self, mock_create_process, mock_os):
         mock_process = mock_create_process.return_value
         mock_process.is_alive.return_value = True
         mock_process.pid = "foo"
-
         fs = FakeStream()
         daemon = DummyWrapper([])
+        daemon.scan_collection.datamanager = FakeDataManager()
         request = (
             '<start_scan>'
             '<targets>'
@@ -352,6 +411,8 @@ class StopCommandTestCase(TestCase):
         )
         daemon.handle_command(request, fs)
         response = fs.get_response()
+
+        daemon.check_pending_scans()
 
         assert_called(mock_create_process)
         assert_called(mock_process.start)

--- a/tests/command/test_commands.py
+++ b/tests/command/test_commands.py
@@ -125,7 +125,7 @@ class StartScanTestCase(TestCase):
         self.assertEqual(vts_collection, {'1.2.3.4': {}, 'vt_groups': []})
         self.assertNotEqual(vts_collection, {'1.2.3.6': {}})
 
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
         assert_called(mock_create_process)
 
     def test_scan_pop_vts(self):
@@ -228,7 +228,7 @@ class StartScanTestCase(TestCase):
         scan_id = response.findtext('id')
         self.assertEqual(daemon.get_scan_vts(scan_id), {})
 
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
         assert_called(mock_create_process)
 
     def test_scan_with_vts_and_param_missing_vt_param_id(self):
@@ -283,7 +283,7 @@ class StartScanTestCase(TestCase):
             daemon.get_scan_vts(scan_id),
             {'1234': {'ABC': '200'}, 'vt_groups': []},
         )
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
         assert_called(mock_create_process)
 
     def test_scan_with_vts_and_param_missing_vt_group_filter(self):
@@ -334,7 +334,7 @@ class StartScanTestCase(TestCase):
 
         self.assertEqual(daemon.get_scan_vts(scan_id), {'vt_groups': ['a']})
 
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
         assert_called(mock_create_process)
 
     @patch("ospd.ospd.create_process")
@@ -355,7 +355,7 @@ class StartScanTestCase(TestCase):
         )
 
         cmd.handle_xml(request)
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
         assert_called(mock_logger.warning)
         assert_called(mock_create_process)
 
@@ -382,7 +382,7 @@ class StartScanTestCase(TestCase):
         self.assertEqual(daemon.get_scan_host(scan_id), 'localhost')
         self.assertEqual(daemon.get_scan_ports(scan_id), '22')
 
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
 
         assert_called(mock_logger.warning)
         assert_called(mock_create_process)
@@ -412,7 +412,7 @@ class StopCommandTestCase(TestCase):
         daemon.handle_command(request, fs)
         response = fs.get_response()
 
-        daemon.check_pending_scans()
+        daemon.start_pending_scans()
 
         assert_called(mock_create_process)
         assert_called(mock_process.start)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -16,6 +16,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import time
+import multiprocessing
 
 from unittest.mock import Mock
 
@@ -48,12 +49,21 @@ class FakeStream:
         return et.fromstring(self.response)
 
 
+class FakeDataManager:
+    def __init__(self):
+        pass
+
+    def dict(self):
+        return dict()
+
+
 class DummyWrapper(OSPDaemon):
     def __init__(self, results, checkresult=True):
         super().__init__()
         self.checkresult = checkresult
         self.results = results
         self.initialized = True
+        self.scan_collection.data_manager = FakeDataManager()
 
     def check(self):
         return self.checkresult

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -507,7 +507,7 @@ class ScanTestCase(unittest.TestCase):
 
         finished = False
 
-        self.daemon.check_pending_scans()
+        self.daemon.start_pending_scans()
         while not finished:
             fs = FakeStream()
             self.daemon.handle_command(
@@ -564,7 +564,7 @@ class ScanTestCase(unittest.TestCase):
         response = fs.get_response()
         scan_id = response.findtext('id')
         finished = False
-        self.daemon.check_pending_scans()
+        self.daemon.start_pending_scans()
         self.daemon.add_scan_error(
             scan_id, host='a', value='something went wrong'
         )
@@ -970,7 +970,7 @@ class ScanTestCase(unittest.TestCase):
         status = response.get('status_text')
         self.assertEqual(status, 'OK')
 
-        self.daemon.check_pending_scans()
+        self.daemon.start_pending_scans()
 
         assert_called(mock_create_process)
         assert_called(mock_process.start)

--- a/tests/test_ssh_daemon.py
+++ b/tests/test_ssh_daemon.py
@@ -22,6 +22,7 @@ import unittest
 
 from ospd import ospd_ssh
 from ospd.ospd_ssh import OSPDaemonSimpleSSH
+from .helper import FakeDataManager
 
 
 class FakeFile(object):
@@ -73,6 +74,7 @@ class fakeparamiko(object):  # pylint: disable=invalid-name
 class DummyWrapper(OSPDaemonSimpleSSH):
     def __init__(self, niceness=10):
         super().__init__(niceness=niceness)
+        self.scan_collection.data_manager = FakeDataManager()
 
     def check(self):
         return True


### PR DESCRIPTION
When a new scan is started, it will not be started directly, but the data information will be stored in the scan table in data manager. The scan is set as PENDING (new scan status added with this PR). 
A new method call from inside the main loop will check for a PENDING scan and will launch the scan in a new fork()'ed process.

This avoid to fork the new scan process with all the data objects inherited from the parent process.
This reduces the memory usage of the new process (data manager and task processes) from ~110MB to ~30MB, for a full and fast single host target scan.