### PR TITLE
Use available memory instead of free memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add [pontos](https://github.com/greenbone/pontos) as dev dependency for
   managing the version information in ospd [#254](https://github.com/greenbone/ospd/pull/254)
 - Add more info about scan progress with progress attribute in get_scans cmd. [#266](https://github.com/greenbone/ospd/pull/266)
+- Add support for scan queuing
+  [#278](https://github.com/greenbone/ospd/pull/278)
+  [#279](https://github.com/greenbone/ospd/pull/279)
+  [#281](https://github.com/greenbone/ospd/pull/281)
 
 ### Changes
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1275,7 +1275,7 @@ class OSPDaemon:
         if not self.min_free_mem_scan_queue:
             return True
 
-        free_mem = psutil.virtual_memory().free / (1024 * 1024)
+        free_mem = psutil.virtual_memory().available / (1024 * 1024)
 
         if free_mem > self.min_free_mem_scan_queue:
             return True

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -39,8 +39,8 @@ def assert_called(mock: Mock):
 
 
 class FakePsutil:
-    def __init__(self, free=None):
-        self.free = free
+    def __init__(self, available=None):
+        self.available = available
 
 
 class FakeStream:

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1111,7 +1111,9 @@ class ScanTestCase(unittest.TestCase):
     def test_free_memory_true(self, mock_psutil):
         self.daemon.min_free_mem_scan_queue = 1000
         # 1.5 GB free
-        mock_psutil.virtual_memory.return_value = FakePsutil(free=1500000000)
+        mock_psutil.virtual_memory.return_value = FakePsutil(
+            available=1500000000
+        )
 
         self.assertTrue(self.daemon.is_enough_free_memory())
 
@@ -1119,7 +1121,9 @@ class ScanTestCase(unittest.TestCase):
     def test_free_memory_false(self, mock_psutil):
         self.daemon.min_free_mem_scan_queue = 2000
         # 1.5 GB free
-        mock_psutil.virtual_memory.return_value = FakePsutil(free=1500000000)
+        mock_psutil.virtual_memory.return_value = FakePsutil(
+            available=1500000000
+        )
 
         self.assertFalse(self.daemon.is_enough_free_memory())
 


### PR DESCRIPTION
When check for enough free memory before starting a scan, check for available memory now

When the command line 'free -h' is called, the output shows two different values: available and free memory. Available is the one with more fluctuation and the one we should check instead of free, because it gives a more realistic value for checking if there is enough memory before starting a queued scan. 

More info can be found in the free command man page.