### PR TITLE
Allow a client to request start_scan during feed update

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -451,7 +451,7 @@ class StartScan(BaseCommand):
         'scan_id': 'Optional UUID value to use as scan ID',
         'parallel': 'Optional nummer of parallel target to scan',
     }
-    must_be_initialized = True
+    must_be_initialized = False
 
     def get_elements(self):
         elements = {}

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1219,6 +1219,13 @@ class OSPDaemon:
         if not current_queued_scans:
             return
 
+        if not self.initialized:
+            logger.info(
+                "New task can not be started because a "
+                "feed update is being performed."
+            )
+            return
+
         logger.info('Currently %d queued scans.', current_queued_scans)
 
         for scan_id in self.scan_collection.ids_iterator():

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -23,8 +23,9 @@
 import time
 import unittest
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, Mock
 
+import logging
 import xml.etree.ElementTree as ET
 
 from defusedxml.common import EntitiesForbidden
@@ -1107,6 +1108,17 @@ class ScanTestCase(unittest.TestCase):
         self.daemon.max_scans = 3
 
         self.assertTrue(self.daemon.is_new_scan_allowed())
+
+    def test_start_queue_scan_daemon_not_init(self):
+        self.daemon.get_count_queued_scans = MagicMock(return_value=10)
+        self.daemon.initialized = False
+        logging.Logger.info = Mock()
+        self.daemon.start_queued_scans()
+
+        logging.Logger.info.assert_called_with(
+            "New task can not be started because a "
+            "feed update is being performed."
+        )
 
     @patch("ospd.ospd.psutil")
     def test_free_memory_true(self, mock_psutil):

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1115,7 +1115,7 @@ class ScanTestCase(unittest.TestCase):
         logging.Logger.info = Mock()
         self.daemon.start_queued_scans()
 
-        logging.Logger.info.assert_called_with(
+        logging.Logger.info.assert_called_with(  # pylint: disable=no-member
             "New task can not be started because a "
             "feed update is being performed."
         )

--- a/tests/test_ssh_daemon.py
+++ b/tests/test_ssh_daemon.py
@@ -76,6 +76,7 @@ class DummyWrapper(OSPDaemonSimpleSSH):
         super().__init__(niceness=niceness)
         self.scan_collection.data_manager = FakeDataManager()
         self.scan_collection.file_storage_dir = '/tmp'
+        self.initialized = True
 
     def check(self):
         return True


### PR DESCRIPTION
The scan is queued and will be started when the feed update finishes.
