### PR TITLE
Change how num of total dead hosts is set

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -751,7 +751,7 @@ class OSPDaemon:
         )
         current_progress['count_dead'] = self.scan_collection.get_count_dead(
             scan_id
-        )
+        ) + self.scan_collection.get_count_dead_alive_detection(scan_id)
         current_progress[
             'count_excluded'
         ] = self.scan_collection.simplify_exclude_host_count(scan_id)


### PR DESCRIPTION
When boreas is activated the amount of dead hosts
is only set via set_amount_dead_hosts().
The number is not manipulated in any other way.
Therefore the amount of dead hosts can be updated
regularily by just replacing the old value of dead
hosts with a new value.

Depends on:
* https://github.com/greenbone/gvm-libs/pull/373
* https://github.com/greenbone/ospd-openvas/pull/283