### PR TITLE
Add attribute to <get_scanner_details> for showing all available parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#288](https://github.com/greenbone/ospd/pull/288)
   [#289](https://github.com/greenbone/ospd/pull/289)
 - Extend get_vts with attribute version_only and return the version [#291](https://github.com/greenbone/ospd/pull/291)
+- Allow to set all openvas parameters which are not strict openvas only parameters via osp. [#301](https://github.com/greenbone/ospd/pull/301)
 
 ### Changes
 - Modify __init__() method and use new syntax for super(). [#186](https://github.com/greenbone/ospd/pull/186)

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -772,7 +772,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   <command>
     <name>get_scanner_details</name>
     <summary>Return scanner description and parameters</summary>
-    <pattern/>
+    <pattern>
+      <attrib>
+        <name>list_all</name>
+        <summary>List all available scanner parameters. Not only those visible to the client.</summary>
+        <type>boolean</type>
+      </attrib>
+    </pattern>
     <response>
       <pattern>
         <attrib>

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -253,9 +253,20 @@ class GetScannerDetails(BaseCommand):
 
         @return: Response string for <get_scanner_details> command.
         """
+        list_all = xml.get('list_all')
+        list_all = True if list_all == '1' else False
+
         desc_xml = Element('description')
         desc_xml.text = self._daemon.get_scanner_description()
         scanner_params = self._daemon.get_scanner_params()
+
+        if not list_all:
+            scanner_params = {
+                key: value
+                for (key, value) in scanner_params.items()
+                if value.get('visible_for_client') is 1
+            }
+
         details = [
             desc_xml,
             OspResponse.create_scanner_params_xml(scanner_params),

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -264,7 +264,7 @@ class GetScannerDetails(BaseCommand):
             scanner_params = {
                 key: value
                 for (key, value) in scanner_params.items()
-                if value.get('visible_for_client') is 1
+                if value.get('visible_for_client')
             }
 
         details = [


### PR DESCRIPTION
* With attribute `list_all` set to `1` all available scanner parameters are listed. 
* Per default `list_all` is considered as `0` and only the parameters visible to the client are shown.
* This way we do not have to change clients (e.g. gsa) for only showing specific parameters to the user.

Depends on:
https://github.com/greenbone/ospd-openvas/pull/293