### PR TITLE
Don't iterate directly over the scans table, as it can change during the iteration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix get_scanner_details(). [#210](https://github.com/greenbone/ospd/pull/210)
 - Fix thread lib leak using daemon mode for python 3.7. [#272](https://github.com/greenbone/ospd/pull/272)
 - Fix scan progress in which all hosts are dead or excluded. [#295](https://github.com/greenbone/ospd/pull/295)
+- Fix start of parallel queued task. [#304](https://github.com/greenbone/ospd/pull/304)
 
 ### Removed
 - Remove support for resume task. [#266](https://github.com/greenbone/ospd/pull/266)

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -231,7 +231,10 @@ class ScanCollection:
     def ids_iterator(self) -> Iterator[str]:
         """ Returns an iterator over the collection's scan IDS. """
 
-        return iter(self.scans_table.keys())
+        # Do not iterate over the scans_table because it can change
+        # during iteration, since it is accessed by multiple processes.
+        scan_id_list = list(self.scans_table)
+        return iter(scan_id_list)
 
     def clean_up_pickled_scan_info(self) -> None:
         """ Remove files of pickled scan info """

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1309,3 +1309,11 @@ class ScanTestCase(unittest.TestCase):
         self.assertEqual(self.daemon.get_count_queued_scans(), 1)
         self.daemon.start_queued_scans()
         self.assertEqual(self.daemon.get_count_queued_scans(), 0)
+
+    def test_ids_iterator_dict_modified(self):
+        self.daemon.scan_collection.scans_table = {'a': 1, 'b': 2}
+
+        for _ in self.daemon.scan_collection.ids_iterator():
+            self.daemon.scan_collection.scans_table['c'] = 3
+
+        self.assertEqual(len(self.daemon.scan_collection.scans_table), 3)


### PR DESCRIPTION
The scans table is accessed by different processes and the iterated dictionary can
change it size.
The given case was that a new task is being queued (add info in the scans table) at same time a task is being taken from the queue to be started (both process access the scan table). But this will solve issues like a finished scan being removed from the scans table during a scans_table iteration.