### PR TITLE
Do not send all params as scanner prefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make ospd-openvas to shut down gracefully
   [#302](https://github.com/greenbone/ospd/pull/302)
   [#307](https://github.com/greenbone/ospd/pull/307)
+- Do not add all params which are in the OSPD_PARAMS dict to the params which are set as scan preferences. [#305](https://github.com/greenbone/ospd/pull/305)
 
 ### Fixed
 - Fix stop scan. Wait for the scan process to be stopped before delete it from the process table. [#204](https://github.com/greenbone/ospd/pull/204)

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -551,6 +551,7 @@ class StartScan(BaseCommand):
         if scanner_params is None:
             raise OspdCommandError('No scanner_params element', 'start_scan')
 
+        # params are the parameters we got from the <scanner_params> XML.
         params = self._daemon.preprocess_scan_params(scanner_params)
 
         # VTS is an optional element. If present should not be empty.

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1357,7 +1357,8 @@ class OSPDaemon:
         """ Creates a new scan.
 
         @target: Target to scan.
-        @options: Miscellaneous scan options.
+        @options: Miscellaneous scan options supplied via <scanner_params>
+                  XML element.
 
         @return: New scan's ID. None if the scan_id already exists.
         """

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -299,13 +299,6 @@ class OSPDaemon:
         for param in xml_params:
             params[param.tag] = param.text or ''
 
-        # Set default values.
-        for key in self.scanner_params:
-            if key not in params:
-                params[key] = self.get_scanner_param_default(key)
-                if self.get_scanner_param_type(key) == 'selection':
-                    params[key] = params[key].split('|')[0]
-
         # Validate values.
         for key in params:
             param_type = self.get_scanner_param_type(key)

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -286,7 +286,14 @@ class ScanCollection:
         options: Optional[Dict] = None,
         vts: Dict = None,
     ) -> str:
-        """ Creates a new scan with provided scan information. """
+        """ Creates a new scan with provided scan information.
+
+        @target: Target to scan.
+        @options: Miscellaneous scan options supplied via <scanner_params>
+                  XML element.
+
+        @return: Scan's ID. None if error occurs.
+        """
 
         if not options:
             options = dict()


### PR DESCRIPTION
Do not add all params which are in the OSPD_PARAMS dict to the params which are set as scan preferences.

Depends on: 
https://github.com/greenbone/ospd-openvas/pull/297