### PR TITLE
Improve/fix exit cleanup function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Make scan_id attribute mandatory for get_scans. [#270](https://github.com/greenbone/ospd/pull/270)
 - Ignore subsequent SIGINT once inside exit_cleanup(). [#273](https://github.com/greenbone/ospd/pull/273)
 - Simplify start_scan() [#275](https://github.com/greenbone/ospd/pull/275)
-- Make ospd-openvas to shut down gracefully  [#302](https://github.com/greenbone/ospd/pull/302)
+- Make ospd-openvas to shut down gracefully
+  [#302](https://github.com/greenbone/ospd/pull/302)
+  [#307](https://github.com/greenbone/ospd/pull/307)
 
 ### Fixed
 - Fix stop scan. Wait for the scan process to be stopped before delete it from the process table. [#204](https://github.com/greenbone/ospd/pull/204)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -440,8 +440,15 @@ class OSPDaemon:
         """ Perform a cleanup before exiting """
         self.scan_collection.clean_up_pickled_scan_info()
 
+        # Stop scans which are not already stopped.
         for scan_id in self.scan_collection.ids_iterator():
-            self.stop_scan(scan_id)
+            status = self.get_scan_status(scan_id)
+            if (
+                status != ScanStatus.STOPPED
+                and status != ScanStatus.FINISHED
+                and status != ScanStatus.INTERRUPTED
+            ):
+                self.stop_scan(scan_id)
 
         while True:
             all_stopped = True

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -450,14 +450,15 @@ class OSPDaemon:
             ):
                 self.stop_scan(scan_id)
 
+        # Wait for scans to be in some stopped state.
         while True:
             all_stopped = True
             for scan_id in self.scan_collection.ids_iterator():
                 status = self.get_scan_status(scan_id)
                 if (
                     status != ScanStatus.STOPPED
-                    or status != ScanStatus.FINISHED
-                    or status != ScanStatus.INTERRUPTED
+                    and status != ScanStatus.FINISHED
+                    and status != ScanStatus.INTERRUPTED
                 ):
                     all_stopped = False
 


### PR DESCRIPTION
Only stop scans which are not already in some kind of stopped state. This PR also fixes a small logic error.