### PR TITLE
[20.08] Mention PID in the scan stopping / stopped log messages.

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -383,7 +383,9 @@ class OSPDaemon:
 
         self.set_scan_status(scan_id, ScanStatus.STOPPED)
 
-        logger.info('%s: Scan stopping %s.', scan_id, scan_process.ident)
+        logger.info(
+            '%s: Stopping Scan with the PID %s.', scan_id, scan_process.ident
+        )
 
         self.stop_scan_cleanup(scan_id)
 
@@ -396,7 +398,9 @@ class OSPDaemon:
             _terminate_process_group(scan_process)
         except ProcessLookupError:
             logger.info(
-                '%s: Scan already stopped %s.', scan_id, scan_process.pid
+                '%s: Scan with the PID %s is already stopped.',
+                scan_id,
+                scan_process.pid,
             )
 
         if scan_process.ident != os.getpid():


### PR DESCRIPTION
Noticed the following entry while checking some logs:

> OSPD[235] 2020-08-01 17:02:03,615: INFO: (ospd.ospd) a15f45b4-034e-48af-9f68-be58e9e83f09: Scan stopping 1675.

Without checking the code it is completely unclear what the last "1675" means. Adding the "PID" text gives some more context.

I'm not absolutely sure if `scan_process.ident` is indeed the PID but a few lines below the following comparison is done so this might be right:

```
if scan_process.ident != os.getpid():
```