### PR TITLE
Fix description for poetry in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix deploy and upload to pypi. [#312](https://github.com/greenbone/ospd/pull/312)
+- Fix metadata for Python wheel distributable [#313](https://github.com/greenbone/ospd/pull/313)
 
 [20.8.1]: https://github.com/greenbone/ospd/compare/v20.8.0...ospd-20.08
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,7 @@ requires = ["setuptools", "wheel"]
 [tool.poetry]
 name = "ospd"
 version = "20.8.0"
-description = """OSPD is a base for scanner wrappers which share the same
-communication protocol: OSP (Open Scanner Protocol)"""
+description = "OSPD is a base for scanner wrappers which share the same communication protocol: OSP (Open Scanner Protocol)"
 authors = ["Greenbone Networks GmbH <info@greenbone.net>"]
 license = "AGPL-3.0-or-later"
 readme = "README.md"


### PR DESCRIPTION
Using a multiline description breaks the METADATA file in the wheel
distributable. pip wasn't able to install the dependencies of ospd.