### PR TITLE
Update to pylint 2.6.0

### DIFF
--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -207,7 +207,7 @@ class GetPerformance(BaseCommand):
             except ValueError:
                 raise OspdCommandError(
                     'Start argument must be integer.', 'get_performance'
-                )
+                ) from None
 
             cmd.append(start)
 
@@ -217,7 +217,7 @@ class GetPerformance(BaseCommand):
             except ValueError:
                 raise OspdCommandError(
                     'End argument must be integer.', 'get_performance'
-                )
+                ) from None
 
             cmd.append(end)
 
@@ -236,7 +236,7 @@ class GetPerformance(BaseCommand):
         except (subprocess.CalledProcessError, OSError) as e:
             raise OspdCommandError(
                 'Bogus get_performance format. %s' % e, 'get_performance'
-            )
+            ) from None
 
         return simple_response_str(
             'get_performance', 200, 'OK', output.decode()
@@ -347,7 +347,7 @@ class GetVts(BaseCommand):
                 )
             except OspdCommandError as filter_error:
                 self._daemon.vts.is_cache_available = True
-                raise OspdCommandError(filter_error)
+                raise filter_error
 
         if not version_only:
             vts_selection = self._daemon.get_vts_selection_list(

--- a/ospd/datapickler.py
+++ b/ospd/datapickler.py
@@ -67,11 +67,11 @@ class DataPickler:
             # create parent directories recursively
             parent_dir = storage_file_path.parent
             parent_dir.mkdir(parents=True, exist_ok=True)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             raise OspdCommandError(
                 'Not possible to access dir for %s. %s' % (filename, e),
                 'start_scan',
-            )
+            ) from e
 
         try:
             pickled_data = pickle.dumps(data_object)
@@ -79,7 +79,7 @@ class DataPickler:
             raise OspdCommandError(
                 'Not possible to pickle scan info for %s. %s' % (filename, e),
                 'start_scan',
-            )
+            ) from e
 
         try:
             with open(
@@ -91,7 +91,7 @@ class DataPickler:
             raise OspdCommandError(
                 'Not possible to store scan info for %s. %s' % (filename, e),
                 'start_scan',
-            )
+            ) from e
         self._fd_close()
 
         return self._pickled_data_hash_generator(pickled_data)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -303,7 +303,7 @@ class OSPDaemon:
                 except ValueError:
                     raise OspdCommandError(
                         'Invalid %s value' % key, 'start_scan'
-                    )
+                    ) from None
 
             if param_type == 'boolean':
                 if params[key] not in [0, 1]:
@@ -1144,9 +1144,9 @@ class OSPDaemon:
         """
         try:
             tree = secET.fromstring(data)
-        except secET.ParseError:
+        except secET.ParseError as e:
             logger.debug("Erroneous client input: %s", data)
-            raise OspdCommandError('Invalid data')
+            raise OspdCommandError('Invalid data') from e
 
         command_name = tree.tag
 

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -234,7 +234,7 @@ class CliParser:
             raise RuntimeError(
                 'Error while parsing config file {config}. Error was '
                 '{message}'.format(config=configfile, message=e)
-            )
+            ) from None
 
         return config
 

--- a/ospd/server.py
+++ b/ospd/server.py
@@ -106,7 +106,7 @@ def validate_cacert_file(cacert: str):
         # Python version < 2.7.9
         return
     except IOError:
-        raise OspdError('CA Certificate not found')
+        raise OspdError('CA Certificate not found') from None
 
     try:
         not_after = context.get_ca_certs()[0]['notAfter']
@@ -114,7 +114,7 @@ def validate_cacert_file(cacert: str):
         not_before = context.get_ca_certs()[0]['notBefore']
         not_before = ssl.cert_time_to_seconds(not_before)
     except (KeyError, IndexError):
-        raise OspdError('CA Certificate is erroneous')
+        raise OspdError('CA Certificate is erroneous') from None
 
     now = int(time.time())
     if not_after < now:
@@ -226,7 +226,7 @@ class UnixSocketServer(BaseServer):
                 "Couldn't bind socket on {}. {}".format(
                     str(self.socket_path), e
                 )
-            )
+            ) from e
 
         if self.socket_path.exists():
             self.socket_path.chmod(self.socket_mode)
@@ -289,7 +289,7 @@ class TlsServer(BaseServer):
                 "Couldn't bind socket on {}:{}. {}".format(
                     self.socket[0], str(self.socket[1]), e
                 )
-            )
+            ) from e
 
     def handle_request(self, request, client_address):
         logger.debug("New connection from %s", client_address)

--- a/poetry.lock
+++ b/poetry.lock
@@ -153,7 +153,7 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "python_version >= \"3.7\" and python_version < \"4.0\" and platform_system == \"Windows\" or sys_platform == \"win32\""
+marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or python_version >= \"3.7\" and python_version < \"4.0\" and platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -342,12 +342,12 @@ description = "python code static checker"
 name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.5.3"
+version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
 colorama = "*"
-isort = ">=4.2.5,<5"
+isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
@@ -469,6 +469,7 @@ version = "1.12.1"
 
 [metadata]
 content-hash = "585d32bd79af05f82fdf42cc30d751e7f440088208c7fd6cf6b17d5090ec026d"
+lock-version = "1.0"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -690,8 +691,8 @@ pycparser = [
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pylint = [
-    {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},
-    {file = "pylint-2.5.3.tar.gz", hash = "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc"},
+    {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
+    {file = "pylint-2.6.0.tar.gz", hash = "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210"},
 ]
 pynacl = [
     {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},


### PR DESCRIPTION
**What**:

Handle newly introduced raise-missing-from feature by either raise from
the catched exception explicitly or by surpressing the original
traceback.

```
except Error as e:
    raise MyException()
```

is actually a

```
except Error as e:
    raise MyException() from e
```

See https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement
for all details.


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

A new version of pylint has been released.

**How**:

`poetry run pylint --disable=R ospd tests`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests (N/A)
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry (N/A)
