### PR TITLE
Add target option for setting dedicated port list for alive detection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [21.4] (unreleased)
 
+### Added
+- Add target option for supplying dedicated port list for alive detection (Boreas only) via OSP. [#323](https://github.com/greenbone/ospd/pull/323)
+
 ### Removed
 - Remove python3.5 support and deprecated methods. [#316](https://github.com/greenbone/ospd/pull/316)
 

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -180,6 +180,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <e>exclude_hosts</e>
       <e>finished_hosts</e>
       <e>alive_test</e>
+      <e>alive_test_ports</e>
       <e>reverse_lookup_unify</e>
       <e>reverse_lookup_only</e>
     </pattern>
@@ -218,6 +219,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <type>string</type>
     </ele>
     <ele>
+      <name>alive_test_ports</name>
+      <summary>Dedicated port list for alive detection. Used for TCP-SYN and TCP-ACK ping when Boreas (scanner preference test_alive_hosts_only) is enabled. If no port list is provided ports 80, 137, 587, 3128, 8081 are used as defaults.</summary>
+      <type>string</type>
+    </ele>
+    <ele>
       <name>reverse_lookup_only</name>
       <summary>Only scan IP addresses that can be resolved into a DNS name.</summary>
       <type>string</type>
@@ -234,6 +240,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
           <hosts>example.org</hosts>
           <ports>T:22,U:5060</ports>
           <alive_test>0</alive_test>
+          <alive_test_ports>22,80,123</alive_test_ports>
           <reverse_lookup_only>0</reverse_lookup_only>
           <reverse_lookup_unify>0</reverse_lookup_unify>
         </target>
@@ -1470,6 +1477,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     <name>ovaldef_file</name>
     <summary>An ovaldef file's content that is base64 encoded</summary>
   </parameter_type>
+
+  <change>
+    <command>START_SCAN</command>
+    <summary>Add support for dedicated port list for alive detection</summary>
+    <description>Target element received new target option alive_test_ports.
+    </description>
+    <version>21.4</version>
+  </change>
 
   <change>
     <command>GET_VTS</command>

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -174,6 +174,7 @@ class OspRequest:
                     </credential>
                 </credentials>
                 <alive_test></alive_test>
+                <alive_test_ports></alive_test_ports>
                 <reverse_lookup_only>1</reverse_lookup_only>
                 <reverse_lookup_unify>0</reverse_lookup_unify>
             </target>
@@ -196,6 +197,7 @@ class OspRequest:
                 'exclude_hosts': '',
                 'finished_hosts': '',
                 'options': {'alive_test': 'ALIVE_TEST_CONSIDER_ALIVE',
+                            'alive_test_ports: '22,80,123',
                             'reverse_lookup_only': '1',
                             'reverse_lookup_unify': '0',
                             },
@@ -222,6 +224,8 @@ class OspRequest:
                     credentials = cls.process_credentials_elements(child)
                 if child.tag == 'alive_test':
                     options['alive_test'] = child.text
+                if child.tag == 'alive_test_ports':
+                    options['alive_test_ports'] = child.text
                 if child.tag == 'reverse_lookup_unify':
                     options['reverse_lookup_unify'] = child.text
                 if child.tag == 'reverse_lookup_only':


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
Add target option for setting dedicated port list for alive detection .

Depends on:
https://github.com/greenbone/ospd-openvas/pull/327
https://github.com/greenbone/gvm-libs/pull/391

**Why**:

<!-- Why are these changes necessary? -->

It enhances the flexibility when doing alive scans.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Used gvm-cli for scans. Added <alive_test_ports>22,80<alive_test_ports> and checked with a print if these ports were actually used during a scan. Checked if defaults were used if no alive_test_ports was provided.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
