### PR TITLE
Fix OSP version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [20.8.2] (unreleased)
+
+### Fixed
+- Fix OSP version. [#326](https://github.com/greenbone/ospd/pull/326)
+
+[20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
+
 ## [20.8.1] (2020-08-12)
 
 ### Fixed

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -64,7 +64,7 @@ from ospd.xml import (
 
 logger = logging.getLogger(__name__)
 
-PROTOCOL_VERSION = "1.2"
+PROTOCOL_VERSION = __version__
 
 SCHEDULER_CHECK_PERIOD = 10  # in seconds
 


### PR DESCRIPTION
**What**:
Use the same version for the protocol as for the module.

**How**:

Install and check with ospd-openvas --version
or with gvm-cli, with the <get_version/> command.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
