### PR TITLE
Add new interface for adding alive test methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add target option for supplying dedicated port list for alive detection (Boreas only) via OSP. [#323](https://github.com/greenbone/ospd/pull/323)
+- Add target option for supplying alive test methods via separate elements. [#329](https://github.com/greenbone/ospd/pull/329)
 
 ### Removed
 - Remove python3.5 support and deprecated methods. [#316](https://github.com/greenbone/ospd/pull/316)

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -1534,6 +1534,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
   </change>
 
   <change>
+    <command>START_SCAN</command>
+    <summary>Add support for supplying alive test methods via separate elements.</summary>
+    <description>Target element received new optional target option alive_test_methods with subelements imcp, tcp_ack, tcp_syn, arp and consider_alive.
+    </description>
+    <version>21.4</version>
+  </change>
+
+  <change>
     <command>GET_VTS</command>
     <summary>Returned object extended with solution method</summary>
     <description>

--- a/doc/OSP.xml
+++ b/doc/OSP.xml
@@ -179,8 +179,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       <e>credentials</e>
       <e>exclude_hosts</e>
       <e>finished_hosts</e>
-      <e>alive_test</e>
       <e>alive_test_ports</e>
+      <or>
+        <e>alive_test</e>
+        <e>alive_test_methods</e>
+      </or>
       <e>reverse_lookup_unify</e>
       <e>reverse_lookup_only</e>
     </pattern>
@@ -196,45 +199,89 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
     </ele>
     <ele>
       <name>credentials</name>
-      <summary>One or many credentials containing the credential for the given hosts.</summary>
+      <summary>One or many credentials containing the credential for the given hosts</summary>
       <pattern>
         <e>credential</e>
       </pattern>
     </ele>
     <ele>
       <name>exclude_hosts</name>
-      <summary>One or many hosts to exclude. The list is comma-separated. Each entry can be a IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. Each wrapper must handle the exclude hosts.
+      <summary>One or many hosts to exclude. The list is comma-separated. Each entry can be a IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. Each wrapper must handle the exclude hosts
       </summary>
       <type>string</type>
     </ele>
     <ele>
       <name>finished_hosts</name>
-      <summary>One or many finished hosts to exclude when the client resumes a task. The list is comma-separated. Each entry can be an IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. The listed hosts will be set as finished before starting the scan. Each wrapper must handle the finished hosts.
+      <summary>One or many finished hosts to exclude when the client resumes a task. The list is comma-separated. Each entry can be an IP address, a CIDR notation, a hostname, a IP range. IPs can be v4 or v6. The listed hosts will be set as finished before starting the scan. Each wrapper must handle the finished hosts
       </summary>
       <type>string</type>
     </ele>
     <ele>
       <name>alive_test</name>
-      <summary>Alive test type to be performed against the target.</summary>
-      <type>string</type>
+      <summary>Alive test type to be performed against the target</summary>
+      <type>integer</type>
+    </ele>
+    <ele>
+      <name>alive_test_methods</name>
+      <summary>Alive test methods to be performed against the target</summary>
+      <pattern>
+        <e>icmp</e>
+      </pattern>
+      <ele>
+        <name>icmp</name>
+        <summary>ICMP ping</summary>
+        <type>boolean</type>
+      </ele>
+      <pattern>
+        <e>tcp_syn</e>
+      </pattern>
+      <ele>
+        <name>tcp_syn</name>
+        <summary>TCP-SYN ping</summary>
+        <type>boolean</type>
+      </ele>
+      <pattern>
+        <e>tcp_ack</e>
+      </pattern>
+      <ele>
+        <name>tcp_ack</name>
+        <summary>TCP-ACK ping</summary>
+        <type>boolean</type>
+      </ele>
+      <pattern>
+        <e>arp</e>
+      </pattern>
+      <ele>
+        <name>arp</name>
+        <summary>ARP ping</summary>
+        <type>boolean</type>
+      </ele>
+      <pattern>
+        <e>consider_alive</e>
+      </pattern>
+      <ele>
+        <name>consider_alive</name>
+        <summary>Consider the target to be alive</summary>
+        <type>boolean</type>
+      </ele>
     </ele>
     <ele>
       <name>alive_test_ports</name>
-      <summary>Dedicated port list for alive detection. Used for TCP-SYN and TCP-ACK ping when Boreas (scanner preference test_alive_hosts_only) is enabled. If no port list is provided ports 80, 137, 587, 3128, 8081 are used as defaults.</summary>
+      <summary>Dedicated port list for alive detection. Used for TCP-SYN and TCP-ACK ping when Boreas (scanner preference test_alive_hosts_only) is enabled. If no port list is provided ports 80, 137, 587, 3128, 8081 are used as defaults</summary>
       <type>string</type>
     </ele>
     <ele>
       <name>reverse_lookup_only</name>
-      <summary>Only scan IP addresses that can be resolved into a DNS name.</summary>
+      <summary>Only scan IP addresses that can be resolved into a DNS name</summary>
       <type>string</type>
     </ele>
     <ele>
       <name>reverse_lookup_unify</name>
-      <summary>If multiple IP addresses resolve to the same DNS name the DNS name will only get scanned once.</summary>
+      <summary>If multiple IP addresses resolve to the same DNS name the DNS name will only get scanned once</summary>
       <type>string</type>
     </ele>
     <example>
-      <summary>Target without credentials.</summary>
+      <summary>Target without credentials</summary>
       <e>
         <target>
           <hosts>example.org</hosts>
@@ -247,7 +294,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
       </e>
     </example>
     <example>
-      <summary>Target with two credentials.</summary>
+      <summary>Target with two credentials</summary>
       <e>
         <target>
           <hosts>192.168.1.0/24</hosts>

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -148,7 +148,7 @@ class OspRequest:
 
     @staticmethod
     def process_alive_test_methods(cred_tree: Element, options: Dict) -> None:
-        """ Receive an XML object with the alive test methods to run
+        """Receive an XML object with the alive test methods to run
         a scan with. Methods are added to the options Dict.
 
         @param

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -147,30 +147,37 @@ class OspRequest:
         return credentials
 
     @staticmethod
-    def process_alive_test_methods(cred_tree: Element, options: Dict) -> None:
+    def process_alive_test_methods(
+        alive_test_tree: Element, options: Dict
+    ) -> None:
         """Receive an XML object with the alive test methods to run
         a scan with. Methods are added to the options Dict.
 
         @param
         <alive_test_methods>
-            </icmp></icmp>
-            </tcp_ack></tcp_ack>
-            </tcp_syn></tcp_syn>
-            </arp></arp>
-            </consider_alive>0</consider_alive>
+            </icmp>boolean(1 or 0)</icmp>
+            </tcp_ack>boolean(1 or 0)</tcp_ack>
+            </tcp_syn>boolean(1 or 0)</tcp_syn>
+            </arp>boolean(1 or 0)</arp>
+            </consider_alive>boolean(1 or 0)</consider_alive>
         </alive_test_methods>
         """
-        for child in cred_tree:
+        for child in alive_test_tree:
             if child.tag == 'icmp':
-                options['icmp'] = child.text
+                if child.text is not None:
+                    options['icmp'] = child.text
             if child.tag == 'tcp_ack':
-                options['tcp_ack'] = child.text
+                if child.text is not None:
+                    options['tcp_ack'] = child.text
             if child.tag == 'tcp_syn':
-                options['tcp_syn'] = child.text
+                if child.text is not None:
+                    options['tcp_syn'] = child.text
             if child.tag == 'arp':
-                options['arp'] = child.text
+                if child.text is not None:
+                    options['arp'] = child.text
             if child.tag == 'consider_alive':
-                options['consider_alive'] = child.text
+                if child.text is not None:
+                    options['consider_alive'] = child.text
 
     @classmethod
     def process_target_element(cls, scanner_target: Element) -> Dict:

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -146,6 +146,32 @@ class OspRequest:
 
         return credentials
 
+    @staticmethod
+    def process_alive_test_methods(cred_tree: Element, options: Dict) -> None:
+        """ Receive an XML object with the alive test methods to run
+        a scan with. Methods are added to the options Dict.
+
+        @param
+        <alive_test_methods>
+            </icmp></icmp>
+            </tcp_ack></tcp_ack>
+            </tcp_syn></tcp_syn>
+            </arp></arp>
+            </consider_alive>0</consider_alive>
+        </alive_test_methods>
+        """
+        for child in cred_tree:
+            if child.tag == 'icmp':
+                options['icmp'] = child.text
+            if child.tag == 'tcp_ack':
+                options['tcp_ack'] = child.text
+            if child.tag == 'tcp_syn':
+                options['tcp_syn'] = child.text
+            if child.tag == 'arp':
+                options['arp'] = child.text
+            if child.tag == 'consider_alive':
+                options['consider_alive'] = child.text
+
     @classmethod
     def process_target_element(cls, scanner_target: Element) -> Dict:
         """Receive an XML object with the target, ports and credentials to run
@@ -222,6 +248,9 @@ class OspRequest:
                     ports = child.text
                 if child.tag == 'credentials':
                     credentials = cls.process_credentials_elements(child)
+                if child.tag == 'alive_test_methods':
+                    options['alive_test_methods'] = '1'
+                    cls.process_alive_test_methods(child, options)
                 if child.tag == 'alive_test':
                     options['alive_test'] = child.text
                 if child.tag == 'alive_test_ports':


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Instead of using a bit field which entails all alive tests we can now also use xml elements for every alive test method.

Depends on:
https://github.com/greenbone/ospd-openvas/pull/331

**Why**:

<!-- Why are these changes necessary? -->

Better usability.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

Tested with python-gvm and following target description with different configurations.

```
<target>
    <alive_test_methods>
        <icmp>0</icmp>
        <tcp_ack>0</tcp_ack>
        <tcp_syn>0</tcp_syn>
        <arp>0</arp>
        <consider_alive>0</consider_alive>
    </alive_test_methods>
    <hosts>127.0.0.1</hosts>
</target>
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
