### PR TITLE
Use empty string instead of None for credentials value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix OSP version. [#326](https://github.com/greenbone/ospd/pull/326)
+- Use empty string instead of None for credential. [#335](https://github.com/greenbone/ospd/pull/335)
+
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/protocol.py
+++ b/ospd/protocol.py
@@ -142,7 +142,9 @@ class OspRequest:
                 credentials[service]['port'] = credential.attrib.get('port')
 
             for param in credential:
-                credentials[service][param.tag] = param.text
+                credentials[service][param.tag] = (
+                    param.text if param.text else ""
+                )
 
         return credentials
 

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -849,6 +849,34 @@ class ScanTestCase(unittest.TestCase):
         response = self.daemon.get_scan_credentials(scan_id)
         self.assertEqual(response, cred_dict)
 
+    def test_target_with_credential_empty_community(self):
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan>'
+            '<scanner_params /><vts><vt id="1.2.3.4" />'
+            '</vts>'
+            '<targets><target>'
+            '<hosts>192.168.0.0/24</hosts><ports>22'
+            '</ports><credentials>'
+            '<credential type="up" service="snmp">'
+            '<community></community></credential>'
+            '</credentials>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+        response = fs.get_response()
+
+        self.assertEqual(response.get('status'), '200')
+
+        cred_dict = {
+            'snmp': {'type': 'up', 'community': ''},
+        }
+        scan_id = response.findtext('id')
+        response = self.daemon.get_scan_credentials(scan_id)
+        self.assertEqual(response, cred_dict)
+
     def test_scan_get_target(self):
         fs = FakeStream()
         self.daemon.handle_command(


### PR DESCRIPTION
**What**:
Set empty string as value when there is an credential param without  value
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The string "None" was sent as preference value instead of the empty string.
<!-- Why are these changes necessary? -->

**How**:
Run a scan with an snmp credential without community. With this patch, you should not see a result indicating failure for snmp v1|2c. Before, a result was shown, as the script checked the snmp with community "None"
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
