### PR TITLE
Fix convertion from ipv4 range to list of addresses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix OSP version. [#326](https://github.com/greenbone/ospd/pull/326)
 - Use empty string instead of None for credential. [#335](https://github.com/greenbone/ospd/pull/335)
-
+- Fix target_to_ipv4_short(). [#338](https://github.com/greenbone/ospd/pull/338)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/network.py
+++ b/ospd/network.py
@@ -78,7 +78,19 @@ def target_to_ipv4_short(target: str) -> Optional[List]:
     except (socket.error, ValueError):
         return None
 
-    start_value = int(binascii.hexlify(bytes(start_packed[3])), 16)
+    # For subnet with mask lower than /24, ip addresses ending in .0 are
+    # allowed.
+    # The next code checks for a range starting with a A.B.C.0.
+    # For the octet equal to 0, bytes() returns an empty binary b'',
+    # wich must be handle in a special way.
+    _start_value = bytes(start_packed[3])
+    if _start_value:
+        start_value = int(binascii.hexlify(_start_value), 16)
+    elif _start_value == b'':
+        start_value = 0
+    else:
+        return None
+
     if end_value < 0 or end_value > 255 or end_value < start_value:
         return None
 

--- a/tests/test_target_convert.py
+++ b/tests/test_target_convert.py
@@ -41,12 +41,12 @@ class ConvertTargetListsTestCase(unittest.TestCase):
             self.assertIn('195.70.81.%d' % i, addresses)
 
     def test_range(self):
-        addresses = target_str_to_list('195.70.81.1-10')
+        addresses = target_str_to_list('195.70.81.0-10')
 
         self.assertIsNotNone(addresses)
-        self.assertEqual(len(addresses), 10)
+        self.assertEqual(len(addresses), 11)
 
-        for i in range(1, 10):
+        for i in range(0, 10):
             self.assertIn('195.70.81.%d' % i, addresses)
 
     def test_target_str_with_trailing_comma(self):


### PR DESCRIPTION
**What**:
For subnet with mask lower than /24, ip addresses ending in .0 are allowed.
This fix add support for ranges including the address ended with .0.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because it possible that a host has an IP address ended with .0
<!-- Why are these changes necessary? -->

**How**:
Start a scan against the target "10.128.64.0-2"
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
