### PR TITLE
Add more information and problem resolution.

### DIFF
--- a/ospd/misc.py
+++ b/ospd/misc.py
@@ -104,7 +104,11 @@ def create_pid(pidfile: str) -> bool:
     pidpath = Path(pidfile)
 
     if pidpath.is_file():
-        LOGGER.error("There is an already running process.")
+        LOGGER.error(
+            "There is an already running process. If no process is running, "
+            "please remove the pid file '%s' manually",
+            str(pidpath.absolute()),
+        )
         return False
 
     try:


### PR DESCRIPTION
The normal behavior of the pidfile is to prevent the daemon to be run twice.
When the ospd-openvas daemon dies unexpectedly or it is killed with SIGKILL (-9) signal,
leaves the pid file, which prevent the daemon to start again.
If this is the case, the pidfile must be removed manually.

**What**:
Add more information and problem resolution.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The normal behavior of the pidfile is to prevent the daemon to be run twice.
When the ospd-openvas daemon dies unexpectedly or it is killed with SIGKILL (-9) signal,
leaves the pid file, which prevent the daemon to start again.
If this is the case, the pidfile must be removed manually.

<!-- Why are these changes necessary? -->

**How**:
Kill -9 ospd-openvas and restart. The new message with the hint to solve the problem should be shown in the log file
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
