### PR TITLE
Return an empty list in case of malformed host in the target list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix OSP version. [#326](https://github.com/greenbone/ospd/pull/326)
 - Use empty string instead of None for credential. [#335](https://github.com/greenbone/ospd/pull/335)
 - Fix target_to_ipv4_short(). [#338](https://github.com/greenbone/ospd/pull/338)
+- Fix malformed target. [#341](https://github.com/greenbone/ospd/pull/341)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/network.py
+++ b/ospd/network.py
@@ -285,7 +285,10 @@ def target_to_list(target: str) -> Optional[List]:
 
 
 def target_str_to_list(target_str: str) -> Optional[List]:
-    """ Parses a targets string into a list of individual targets. """
+    """Parses a targets string into a list of individual targets.
+    Return a list of host or None.
+    Return an empty list in case of malformed target
+    """
     new_list = list()
 
     if not target_str:
@@ -301,7 +304,7 @@ def target_str_to_list(target_str: str) -> Optional[List]:
             new_list.extend(target_list)
         else:
             __LOGGER.info("%s: Invalid target value", target)
-            return None
+            return []
 
     return list(collections.OrderedDict.fromkeys(new_list))
 

--- a/ospd/network.py
+++ b/ospd/network.py
@@ -286,8 +286,8 @@ def target_to_list(target: str) -> Optional[List]:
 
 def target_str_to_list(target_str: str) -> Optional[List]:
     """Parses a targets string into a list of individual targets.
-    Return a list of host or None.
-    Return an empty list in case of malformed target
+    Return a list of hosts, None if supplied target_str is None or
+    empty, or an empty list in case of malformed target.
     """
     new_list = list()
 

--- a/tests/test_target_convert.py
+++ b/tests/test_target_convert.py
@@ -40,6 +40,20 @@ class ConvertTargetListsTestCase(unittest.TestCase):
         for i in range(1, 255):
             self.assertIn('195.70.81.%d' % i, addresses)
 
+    def test_bad_ipv4_cidr(self):
+        addresses = target_str_to_list('195.70.81.0/32')
+        self.assertIsNotNone(addresses)
+        self.assertEqual(len(addresses), 0)
+
+        addresses = target_str_to_list('195.70.81.0/31')
+        self.assertIsNotNone(addresses)
+        self.assertEqual(len(addresses), 0)
+
+    def test_good_ipv4_cidr(self):
+        addresses = target_str_to_list('195.70.81.0/30')
+        self.assertIsNotNone(addresses)
+        self.assertEqual(len(addresses), 2)
+
     def test_range(self):
         addresses = target_str_to_list('195.70.81.0-10')
 


### PR DESCRIPTION
**What**:
Return an empty list in case of malformed host in the target list.
This avoid OSPD to crash during calculation of the scan progress.
Now in conjunction with greenbone/openvas#625 the scan finishes with errors, but nicely.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
OSPD check the length of the host list during the scan progress calculation. As the target is not empty, but with errors, the scan started but on error it had returned None, which caused ospd to crash.

<!-- Why are these changes necessary? -->

**How**:
Start a scan with gvm-cli (gsa already checks for malformed target) wiht 192.168.0.1/32 as host target.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
