### PR TITLE
fix target_to_ipv4_short  failure

### DIFF
--- a/ospd/network.py
+++ b/ospd/network.py
@@ -78,7 +78,8 @@ def target_to_ipv4_short(target: str) -> Optional[List]:
     except (socket.error, ValueError):
         return None
 
-    start_value = int(binascii.hexlify(bytes(start_packed[3])), 16)
+    #start_value = int(binascii.hexlify(bytes(start_packed[3])), 16)
+    start_value = start_packed[3]
     if end_value < 0 or end_value > 255 or end_value < start_value:
         return None
 


### PR DESCRIPTION

**What**:

fix bug in target_to_ipv4_short, failed to parse target like '10.1.2.3-80'

**Why**:

 for binascii.hexlify(start_packed[3]) cause TypeError: a bytes-like object is required, not 'int'

**How**:

change the code : start_value = int(binascii.hexlify(start_packed[3]), 16)
to: start_value = int(binascii.hexlify(start_packed[3:4]), 16)
or simply: start_value = start_packed[3]
that's ok.

**Checklist**:


- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
