### PR TITLE
Always set end_time for interrupted scans.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Allow the scanner to update total count of hosts. [#332](https://github.com/greenbone/ospd/pull/332)
 - Add more debug logging. [#352](https://github.com/greenbone/ospd/pull/352)
+- Set end_time for interrupted scans. [#353](https://github.com/greenbone/ospd/pull/353)
 
 ### Fixed
 - Fix OSP version. [#326](https://github.com/greenbone/ospd/pull/326)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1503,7 +1503,6 @@ class OSPDaemon:
             and not scan_process.is_alive()
         ):
             if not status == ScanStatus.STOPPED:
-                self.set_scan_status(scan_id, ScanStatus.STOPPED)
                 self.add_scan_error(
                     scan_id, name="", host="", value="Scan process Failure"
                 )

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -350,7 +350,7 @@ class ScanCollection:
     def set_status(self, scan_id: str, status: ScanStatus) -> None:
         """ Sets scan_id scan's status. """
         self.scans_table[scan_id]['status'] = status
-        if status == ScanStatus.STOPPED:
+        if status == ScanStatus.STOPPED or status == ScanStatus.INTERRUPTED:
             self.scans_table[scan_id]['end_time'] = int(time.time())
 
     def get_status(self, scan_id: str) -> ScanStatus:

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1036,6 +1036,52 @@ class ScanTestCase(unittest.TestCase):
         )
         self.assertEqual(rounded_progress, 66)
 
+    def test_set_status_interrupted(self):
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan parallel="2">'
+            '<scanner_params />'
+            '<targets><target>'
+            '<hosts>localhost1</hosts>'
+            '<ports>22</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+        response = fs.get_response()
+        scan_id = response.findtext('id')
+
+        end_time = self.daemon.scan_collection.get_end_time(scan_id)
+        self.assertEqual(end_time, 0)
+
+        self.daemon.interrupt_scan(scan_id)
+        end_time = self.daemon.scan_collection.get_end_time(scan_id)
+        self.assertNotEqual(end_time, 0)
+
+    def test_set_status_stopped(self):
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan parallel="2">'
+            '<scanner_params />'
+            '<targets><target>'
+            '<hosts>localhost1</hosts>'
+            '<ports>22</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+        response = fs.get_response()
+        scan_id = response.findtext('id')
+
+        end_time = self.daemon.scan_collection.get_end_time(scan_id)
+        self.assertEqual(end_time, 0)
+
+        self.daemon.set_scan_status(scan_id, ScanStatus.STOPPED)
+        end_time = self.daemon.scan_collection.get_end_time(scan_id)
+        self.assertNotEqual(end_time, 0)
+
     def test_calculate_progress_without_current_hosts(self):
 
         fs = FakeStream()


### PR DESCRIPTION
**What**:
Always set end_time for interrupted scans.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
end-time was set via set_scan_status (stopped). Now, the scan can be interrupted directly and the end time will be set.
<!-- Why are these changes necessary? -->

**How**:
Interrupt a running scan and check with <get_scans="SCAN-ID"/>that the end_time is set.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
