### PR TITLE
Initialize end_time with create_scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use empty string instead of None for credential. [#335](https://github.com/greenbone/ospd/pull/335)
 - Fix target_to_ipv4_short(). [#338](https://github.com/greenbone/ospd/pull/338)
 - Fix malformed target. [#341](https://github.com/greenbone/ospd/pull/341)
+- Initialize end_time with create_scan. [#354](https://github.com/greenbone/ospd/pull/354)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -323,6 +323,7 @@ class ScanCollection:
         scan_info['status'] = ScanStatus.QUEUED
         scan_info['credentials'] = credentials
         scan_info['start_time'] = int(time.time())
+        scan_info['end_time'] = 0
 
         scan_info_to_pickle = {
             'target': target,


### PR DESCRIPTION
**What**:
Initialize end_time with create_scan
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Some methods assume `end_time` is set.
Close issue greenbone/ospd-openvas#361

<!-- Why are these changes necessary? -->

**How**:
Set the option `scaninfo_store_time` and start a scan. Without this patch, the scan crashed. 

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
