### PR TITLE
Fix get_count_total(). Accept -1 value set by the server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix target_to_ipv4_short(). [#338](https://github.com/greenbone/ospd/pull/338)
 - Fix malformed target. [#341](https://github.com/greenbone/ospd/pull/341)
 - Initialize end_time with create_scan. [#354](https://github.com/greenbone/ospd/pull/354)
+- Fix get_count_total(). Accept -1 value set by the server. [#355](https://github.com/greenbone/ospd/pull/355)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -393,7 +393,18 @@ class ScanCollection:
         """ Get a scan's total host count. """
 
         count_total = self.scans_table[scan_id]['count_total']
-        if not count_total:
+
+        # The value set by the server has priority over the value
+        # calculated from the original target list by ospd.
+        # As ospd is not intelligent enough to check the amount of valid
+        # hosts, check for duplicated or invalid hosts, consider a negative
+        # value set for the server, in case it detects an invalid target string
+        # or a different amount than the orignal amount in the target list.
+        if count_total == -1:
+            count_total = 0
+        # If the server does not set the total host count
+        # ospd set the amount of host from the original host list.
+        elif not count_total:
             count_total = self.get_host_count(scan_id)
             self.update_count_total(scan_id, count_total)
 
@@ -458,7 +469,7 @@ class ScanCollection:
             )
         except ZeroDivisionError:
             # Consider the case in which all hosts are dead or excluded
-            LOGGER.debug('%s: All hosts dead or excluded.')
+            LOGGER.debug('%s: All hosts dead or excluded.', scan_id)
             t_prog = ScanProgress.FINISHED.value
 
         return t_prog

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1162,6 +1162,32 @@ class ScanTestCase(unittest.TestCase):
         count = self.daemon.scan_collection.get_count_total(scan_id)
         self.assertEqual(count, 3)
 
+    def test_set_scan_total_hosts_invalid_target(self):
+
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan parallel="2">'
+            '<scanner_params />'
+            '<targets><target>'
+            '<hosts>localhost1, localhost2, localhost3, localhost4</hosts>'
+            '<ports>22</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+
+        response = fs.get_response()
+        scan_id = response.findtext('id')
+
+        count = self.daemon.scan_collection.get_count_total(scan_id)
+        self.assertEqual(count, 4)
+
+        # The total host is set by the server as -1, because invalid target
+        self.daemon.set_scan_total_hosts(scan_id, -1)
+        count = self.daemon.scan_collection.get_count_total(scan_id)
+        self.assertEqual(count, 0)
+
     def test_get_scan_progress_xml(self):
 
         fs = FakeStream()


### PR DESCRIPTION
**What**:

The value set by the server has priority over the value
calculated from the original target list by ospd.
As ospd is not intelligent enough to check the amount of valid
hosts, check for duplicated or invalid hosts, consider a negative
value set for the server, in case it detects an invalid target string
or a different amount than the orignal amount in the target list.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Let ospd to set a scan with an invalid target as `finished` instead of interrupted, but there is no other result than the error message to inform the client about the invalid target.

<!-- Why are these changes necessary? -->

**How**:
- Set debug log level in ospd.
- Start a scan with an invalid target list (only possible via gvm-cli, as gsa wont you to create a invalid target).
- check with `<get_scans>` that the scan results xml element has "status = finished" and "progress=100"
- check that the only result is the error message.

```
$ gvm-cli --protocol OSP --timeout 120 socket --socketpath=/home/jnicola/install/var/run/ospd/openvas.sock --xml "<get_scans scan_id='829097a9-85d5-4bb8-bac0-e64c362b2836'/>"|xmlstarlet fo
<?xml version="1.0"?>
<get_scans_response status="200" status_text="OK">
  <scan end_time="1611925139" id="829097a9-85d5-4bb8-bac0-e64c362b2836" progress="100" start_time="1611925136" status="finished" target="some$invalid.target.net.%com">
    <results>
      <result host="" hostname="" name="" port=" " qod="" severity="" test_id="" type="Error Message" uri="">Invalid target list: some$invalid.target.net.%com.</result>
    </results>
  </scan>
</get_scans_response>
```

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
