### PR TITLE
Fix typos.

### DIFF
--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1295,7 +1295,7 @@ class OSPDaemon:
         if self.scan_exists(scan_id) and command_name == "get_scans":
             if write_success:
                 logger.debug(
-                    '%s: Results sent succesfully to the client. Cleaning '
+                    '%s: Results sent successfully to the client. Cleaning '
                     'temporary result list.',
                     scan_id,
                 )

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -399,7 +399,7 @@ class ScanCollection:
         # As ospd is not intelligent enough to check the amount of valid
         # hosts, check for duplicated or invalid hosts, consider a negative
         # value set for the server, in case it detects an invalid target string
-        # or a different amount than the orignal amount in the target list.
+        # or a different amount than the original amount in the target list.
         if count_total == -1:
             count_total = 0
         # If the server does not set the total host count


### PR DESCRIPTION
From codespell:

```
./ospd/ospd.py:1298: succesfully ==> successfully
./ospd/scan.py:402: orignal ==> original
```