### PR TITLE
Fix get_count_total(). Consider 0 value set by the server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix malformed target. [#341](https://github.com/greenbone/ospd/pull/341)
 - Initialize end_time with create_scan. [#354](https://github.com/greenbone/ospd/pull/354)
 - Fix get_count_total(). Accept -1 value set by the server. [#355](https://github.com/greenbone/ospd/pull/355)
+- Fix get_count_total(). Consider 0 value set by the server. [#366](https://github.com/greenbone/ospd/pull/366)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -287,7 +287,7 @@ class ScanCollection:
         scan_info['target_progress'] = dict()
         scan_info['count_alive'] = 0
         scan_info['count_dead'] = 0
-        scan_info['count_total'] = 0
+        scan_info['count_total'] = None
         scan_info['target'] = unpickled_scan_info.pop('target')
         scan_info['vts'] = unpickled_scan_info.pop('vts')
         scan_info['options'] = unpickled_scan_info.pop('options')
@@ -404,7 +404,7 @@ class ScanCollection:
             count_total = 0
         # If the server does not set the total host count
         # ospd set the amount of host from the original host list.
-        elif not count_total:
+        elif count_total is None:
             count_total = self.get_host_count(scan_id)
             self.update_count_total(scan_id, count_total)
 

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1183,6 +1183,35 @@ class ScanTestCase(unittest.TestCase):
         count = self.daemon.scan_collection.get_count_total(scan_id)
         self.assertEqual(count, 3)
 
+    def test_set_scan_total_hosts_zero(self):
+
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan parallel="2">'
+            '<scanner_params />'
+            '<targets><target>'
+            '<hosts>localhost1, localhost2, localhost3, localhost4</hosts>'
+            '<ports>22</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+
+        response = fs.get_response()
+        scan_id = response.findtext('id')
+
+        # Default calculated by ospd with the hosts in the target
+        count = self.daemon.scan_collection.get_count_total(scan_id)
+        self.assertEqual(count, 4)
+
+        # Set to 0 (all hosts unresolved, dead, invalid target) via
+        # the server. This one has priority and must be still 0 and
+        # never overwritten with the calculation from host list
+        self.daemon.set_scan_total_hosts(scan_id, 0)
+        count = self.daemon.scan_collection.get_count_total(scan_id)
+        self.assertEqual(count, 0)
+
     def test_set_scan_total_hosts_invalid_target(self):
 
         fs = FakeStream()


### PR DESCRIPTION
**What**:
Fix get_count_total(). Consider 0 value set by the server.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Consider the possibility that the server finds 0 alive hosts, and it must not
be overwritten with the value calculated by ospd from the target.
None means that it was not set, 0 if set by the server and must not be overwritten.

<!-- Why are these changes necessary? -->

**How**:
Start a scan with a single host name in the target which can't be resolved. Without the patch it ends as interrupted. With the patch the scan finishes as expected.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
