### PR TITLE
Remove exclude hosts which do not belong to the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initialize end_time with create_scan. [#354](https://github.com/greenbone/ospd/pull/354)
 - Fix get_count_total(). Accept -1 value set by the server. [#355](https://github.com/greenbone/ospd/pull/355)
 - Fix get_count_total(). Consider 0 value set by the server. [#366](https://github.com/greenbone/ospd/pull/366)
+- Remove exclude hosts which do not belong to the target for the scan progress calculation. [#377](https://github.com/greenbone/ospd/pull/377)
 
 [20.8.2]: https://github.com/greenbone/ospd/compare/v20.8.1...ospd-20.08
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -829,7 +829,7 @@ class OSPDaemon:
         )
         current_progress[
             'count_excluded'
-        ] = self.scan_collection.simplify_exclude_host_count(scan_id)
+        ] = self.scan_collection.get_simplified_exclude_host_count(scan_id)
         current_progress['count_total'] = self.scan_collection.get_count_total(
             scan_id
         )

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -458,7 +458,7 @@ class ScanCollection:
         in the target."""
 
         total_hosts = self.get_count_total(scan_id)
-        exc_hosts = self.simplify_exclude_host_count(scan_id)
+        exc_hosts = self.get_simplified_exclude_host_count(scan_id)
         count_alive = self.get_count_alive(scan_id)
         count_dead = self.get_count_dead(scan_id)
         host_progresses = self.get_current_target_progress(scan_id)

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -448,10 +448,11 @@ class ScanCollection:
                     invalid_exc_hosts += 1
 
         if invalid_exc_hosts > 0:
-            LOGGER.debug(
-                "Please check the excluded host list. It contains invalid "
-                "hosts which do not belongs to the target. %d hosts were "
-                "removed from the excluded host list",
+            LOGGER.warning(
+                "Please check the excluded host list. It contains "
+                "hosts which do not belong to the target. %d hosts were "
+                "removed from the excluded host list. This warning can be "
+                "ignored if this was done on purpose.",
                 invalid_exc_hosts,
             )
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -442,6 +442,16 @@ class ScanCollection:
 
         return excluded_simplified
 
+    def get_simplified_exclude_host_count(self, scan_id: str) -> int:
+        """ Get a scan's excluded host count. """
+        excluded_simplified = self.scans_table[scan_id]['excluded_simplified']
+        # Check for None because it is the init value, as excluded can be 0
+        # as well
+        if excluded_simplified is not None:
+            return excluded_simplified
+
+        return self.simplify_exclude_host_count(scan_id)
+
     def calculate_target_progress(self, scan_id: str) -> int:
         """Get a target's current progress value.
         The value is calculated with the progress of each single host

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -430,10 +430,28 @@ class ScanCollection:
             self.get_finished_hosts(scan_id)
         )
 
+        # Remove finished hosts from excluded host list
         if finished_hosts_list and exc_hosts_list:
             for finished in finished_hosts_list:
                 if finished in exc_hosts_list:
                     exc_hosts_list.remove(finished)
+
+        # Remove excluded hosts which don't belong to the target list
+        host_list = target_str_to_list(self.get_host_list(scan_id))
+        invalid_exc_hosts = 0
+        if exc_hosts_list:
+            for exc_host in exc_hosts_list:
+                if exc_host not in host_list:
+                    exc_hosts_list.remove(exc_host)
+                    invalid_exc_hosts += 1
+
+        if invalid_exc_hosts > 0:
+            LOGGER.debug(
+                "Please check the excluded host list. It contains invalid "
+                "hosts which do not belongs to the target. %d hosts were "
+                "removed from the excluded host list",
+                invalid_exc_hosts,
+            )
 
         # Set scan_info's excluded simplified to propagate excluded count
         # to parent process.

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -288,6 +288,7 @@ class ScanCollection:
         scan_info['count_alive'] = 0
         scan_info['count_dead'] = 0
         scan_info['count_total'] = None
+        scan_info['excluded_simplified'] = None
         scan_info['target'] = unpickled_scan_info.pop('target')
         scan_info['vts'] = unpickled_scan_info.pop('vts')
         scan_info['options'] = unpickled_scan_info.pop('options')

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -424,7 +424,6 @@ class ScanCollection:
         Return:
             Count of excluded host.
         """
-
         exc_hosts_list = target_str_to_list(self.get_exclude_hosts(scan_id))
 
         finished_hosts_list = target_str_to_list(
@@ -436,7 +435,12 @@ class ScanCollection:
                 if finished in exc_hosts_list:
                     exc_hosts_list.remove(finished)
 
-        return len(exc_hosts_list) if exc_hosts_list else 0
+        # Set scan_info's excluded simplified to propagate excluded count
+        # to parent process.
+        excluded_simplified = len(exc_hosts_list) if exc_hosts_list else 0
+        self.scans_table[scan_id]['excluded_simplified'] = excluded_simplified
+
+        return excluded_simplified
 
     def calculate_target_progress(self, scan_id: str) -> int:
         """Get a target's current progress value.

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -438,11 +438,13 @@ class ScanCollection:
 
         # Remove excluded hosts which don't belong to the target list
         host_list = target_str_to_list(self.get_host_list(scan_id))
+        excluded_simplified = 0
         invalid_exc_hosts = 0
         if exc_hosts_list:
             for exc_host in exc_hosts_list:
-                if exc_host not in host_list:
-                    exc_hosts_list.remove(exc_host)
+                if exc_host in host_list:
+                    excluded_simplified += 1
+                else:
                     invalid_exc_hosts += 1
 
         if invalid_exc_hosts > 0:
@@ -455,7 +457,6 @@ class ScanCollection:
 
         # Set scan_info's excluded simplified to propagate excluded count
         # to parent process.
-        excluded_simplified = len(exc_hosts_list) if exc_hosts_list else 0
         self.scans_table[scan_id]['excluded_simplified'] = excluded_simplified
 
         return excluded_simplified

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1238,6 +1238,40 @@ class ScanTestCase(unittest.TestCase):
         count = self.daemon.scan_collection.get_count_total(scan_id)
         self.assertEqual(count, 0)
 
+    def test_scan_invalid_excluded_hosts(self):
+
+        logging.Logger.debug = Mock()
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan parallel="2">'
+            '<scanner_params />'
+            '<targets><target>'
+            '<hosts>192.168.0.0/24</hosts>'
+            '<exclude_hosts>192.168.0.1-192.168.0.200,10.0.0.0/24'
+            '</exclude_hosts>'
+            '<ports>22</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+        self.daemon.start_queued_scans()
+
+        response = fs.get_response()
+        scan_id = response.findtext('id')
+
+        # Count only the excluded hosts present in the original target.
+        count = self.daemon.scan_collection.get_simplified_exclude_host_count(
+            scan_id
+        )
+        self.assertEqual(count, 200)
+
+        logging.Logger.debug.assert_called_with(  # pylint: disable=no-member
+            "Please check the excluded host list. It contains invalid hosts "
+            "which do not belongs to the target. %d hosts were removed from "
+            "the excluded host list",
+            254,
+        )
+
     def test_get_scan_progress_xml(self):
 
         fs = FakeStream()

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1240,7 +1240,7 @@ class ScanTestCase(unittest.TestCase):
 
     def test_scan_invalid_excluded_hosts(self):
 
-        logging.Logger.debug = Mock()
+        logging.Logger.warning = Mock()
         fs = FakeStream()
         self.daemon.handle_command(
             '<start_scan parallel="2">'
@@ -1265,10 +1265,11 @@ class ScanTestCase(unittest.TestCase):
         )
         self.assertEqual(count, 200)
 
-        logging.Logger.debug.assert_called_with(  # pylint: disable=no-member
-            "Please check the excluded host list. It contains invalid hosts "
-            "which do not belongs to the target. %d hosts were removed from "
-            "the excluded host list",
+        logging.Logger.warning.assert_called_with(  # pylint: disable=no-member
+            "Please check the excluded host list. It contains hosts "
+            "which do not belong to the target. %d hosts were removed from "
+            "the excluded host list. This warning can be ignored if this "
+            "was done on purpose.",
             254,
         )
 


### PR DESCRIPTION
**What**:
Remove invalid exclude hosts which do not belongs to the target
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Excluded hosts which don't belong to the target generate interrupted scans, because a wrong scan progress calculation
<!-- Why are these changes necessary? -->

**How**:
- Create a target: 192.168.0.0/24
- Exclude hosts: 192.168.0.1-192.168.0.200, 10.0.0.0/24 <--- this network is not in the target above.
- Run the scan.

With the patch, the scan should  end as expected. Without the patch, it ends as interrupted.
￼
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
