### PR TITLE
Changed timezone of logger to UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add method to validate port lists. [#393](https://github.com/greenbone/ospd/pull/393)
 
 ### Changed
+- Set Log Timestamp to UTC. [#394](https://github.com/greenbone/ospd-openvas/pull/394)
+
 ### Fixed
 ### Removed
 

--- a/ospd/logger.py
+++ b/ospd/logger.py
@@ -18,6 +18,7 @@
 import logging
 import os
 import configparser
+import time
 
 from logging.config import fileConfig
 from pathlib import Path
@@ -96,4 +97,5 @@ def init_logging(
         config['logger_root'] = DEFAULT_ROOT_LOGGER
 
     fileConfig(config, disable_existing_loggers=False)
+    logging.Formatter.converter = time.gmtime
     logging.getLogger()


### PR DESCRIPTION
**What**:
The logger now uses UTC for timestamps.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
GVM, GSA and openVAS-Scanner used UTC and ospd-openvas used local time.

<!-- Why are these changes necessary? -->

**How**:
When initializing the Logger the timezone is set to UTC. It works when starting ospd-openvas.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
