### PR TITLE
Added option to enable mqtt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add method to validate port lists. 
   [#393](https://github.com/greenbone/ospd/pull/393)
   [#395](https://github.com/greenbone/ospd/pull/395)
-- Add option to set MQTT Broker [#400] (https://github.com/greenbone/ospd/pull/400)
+- Add option to set MQTT Broker [#400](https://github.com/greenbone/ospd/pull/400)
 
 ### Changed
 - Set Log Timestamp to UTC. [#394](https://github.com/greenbone/ospd-openvas/pull/394)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add method to validate port lists. 
   [#393](https://github.com/greenbone/ospd/pull/393)
   [#395](https://github.com/greenbone/ospd/pull/395)
+- Add option to set MQTT Broker [#400] (https://github.com/greenbone/ospd/pull/400)
 
 ### Changed
 - Set Log Timestamp to UTC. [#394](https://github.com/greenbone/ospd-openvas/pull/394)

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -40,6 +40,7 @@ DEFAULT_SCANINFO_STORE_TIME = 0  # in hours
 DEFAULT_MAX_SCAN = 0  # 0 = disable
 DEFAULT_MIN_FREE_MEM_SCAN_QUEUE = 0  # 0 = Disable
 DEFAULT_MAX_QUEUED_SCANS = 0  # 0 = Disable
+DEFAULT_MQTT = ""  # "" = Disable MQTT
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -188,6 +189,13 @@ class CliParser:
             help='Maximum number allowed of queued scans before '
             'starting to reject new scans. '
             'Default %(default)s, disabled',
+        )
+        parser.add_argument(
+            '--mqtt',
+            default=DEFAULT_MQTT,
+            type=str,
+            help='Sets the hostname or IP address of the remote broker. '
+            'If not set, redis is used instead.',
         )
 
         self.parser = parser

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -40,7 +40,7 @@ DEFAULT_SCANINFO_STORE_TIME = 0  # in hours
 DEFAULT_MAX_SCAN = 0  # 0 = disable
 DEFAULT_MIN_FREE_MEM_SCAN_QUEUE = 0  # 0 = Disable
 DEFAULT_MAX_QUEUED_SCANS = 0  # 0 = Disable
-DEFAULT_MQTT = ""  # "" = Disable MQTT
+DEFAULT_MQTT = None  # "" = Disable MQTT
 
 ParserType = argparse.ArgumentParser
 Arguments = argparse.Namespace
@@ -195,7 +195,8 @@ class CliParser:
             default=DEFAULT_MQTT,
             type=str,
             help='Sets the hostname or IP address of the remote broker. '
-            'If not set, redis is used instead.',
+            'If not set, redis is used instead.'
+            'Default %(default)s, disabled',
         )
 
         self.parser = parser


### PR DESCRIPTION
**What**:
Added Setting to enable MQTT for ospd-openvas. This settings allows to set the MQTT broker. Leave it empty to use redis instead.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To support MQTT.

<!-- Why are these changes necessary? -->

**How**:
Test it via ospd-openvas.

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
