### PR TITLE
Queue wait time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [20.8.3] (Unreleased)
 ### Added
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+Do not start all queued scans simultaneously once available memory is enough. [#401](https://github.com/greenbone/ospd/pull/401)
 
 [Unreleased]: https://github.com/greenbone/ospd/compare/v20.8.2...HEAD
 
 
-## (20.8.2) - 2021-02-01
+## [20.8.2] (2021-02-01)
 
 ### Added
 - Allow the scanner to update total count of hosts. [#332](https://github.com/greenbone/ospd/pull/332)

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -142,6 +142,7 @@ class OSPDaemon:
         self.max_scans = max_scans
         self.min_free_mem_scan_queue = min_free_mem_scan_queue
         self.max_queued_scans = max_queued_scans
+        self.last_scan_start_time = 0
 
         self.scaninfo_store_time = kwargs.get('scaninfo_store_time')
 
@@ -1385,6 +1386,7 @@ class OSPDaemon:
                 self.set_scan_status(scan_id, ScanStatus.INIT)
 
                 current_queued_scans = current_queued_scans - 1
+                self.last_scan_start_time = time.time()
                 logger.info('Starting scan %s.', scan_id)
             elif scan_is_queued and not scan_allowed:
                 return
@@ -1402,6 +1404,14 @@ class OSPDaemon:
                 'Not possible to run a new scan. Max scan limit set '
                 'to %d reached.',
                 self.max_scans,
+            )
+            return False
+
+        time_between_start_scan = time.time() - self.last_scan_start_time
+        if time_between_start_scan < 60:
+            logger.debug(
+                'Not possible to run a new scan right now, a scan have been '
+                'just started.'
             )
             return False
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1574,10 +1574,11 @@ class OSPDaemon:
         return count
 
     def get_count_running_scans(self) -> int:
-        """ Get the amount of scans with RUNNING status """
+        """ Get the amount of scans with INIT/RUNNING status """
         count = 0
         for scan_id in self.scan_collection.ids_iterator():
-            if self.get_scan_status(scan_id) == ScanStatus.RUNNING:
+            status = self.get_scan_status(scan_id)
+            if status == ScanStatus.RUNNING or status == ScanStatus.INIT:
                 count += 1
         return count
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -69,6 +69,8 @@ PROTOCOL_VERSION = __version__
 
 SCHEDULER_CHECK_PERIOD = 10  # in seconds
 
+MIN_TIME_BETWEEN_START_SCAN = 60  # in seconds
+
 BASE_SCANNER_PARAMS = {
     'debug_mode': {
         'type': 'boolean',
@@ -1407,14 +1409,6 @@ class OSPDaemon:
             )
             return False
 
-        time_between_start_scan = time.time() - self.last_scan_start_time
-        if time_between_start_scan < 60:
-            logger.debug(
-                'Not possible to run a new scan right now, a scan have been '
-                'just started.'
-            )
-            return False
-
         return True
 
     def is_enough_free_memory(self) -> bool:
@@ -1427,6 +1421,16 @@ class OSPDaemon:
         """
         if not self.min_free_mem_scan_queue:
             return True
+
+        # If min_free_mem_scan_queue option is set, also wait some time
+        # between scans.
+        time_between_start_scan = time.time() - self.last_scan_start_time
+        if time_between_start_scan < MIN_TIME_BETWEEN_START_SCAN:
+            logger.debug(
+                'Not possible to run a new scan right now, a scan have been '
+                'just started.'
+            )
+            return False
 
         free_mem = psutil.virtual_memory().available / (1024 * 1024)
 

--- a/ospd/ospd.py
+++ b/ospd/ospd.py
@@ -1423,9 +1423,13 @@ class OSPDaemon:
             return True
 
         # If min_free_mem_scan_queue option is set, also wait some time
-        # between scans.
+        # between scans. Consider the case in which the last scan
+        # finished in a few seconds and there is no need to wait.
         time_between_start_scan = time.time() - self.last_scan_start_time
-        if time_between_start_scan < MIN_TIME_BETWEEN_START_SCAN:
+        if (
+            time_between_start_scan < MIN_TIME_BETWEEN_START_SCAN
+            and self.get_count_running_scans()
+        ):
             logger.debug(
                 'Not possible to run a new scan right now, a scan have been '
                 'just started.'
@@ -1566,6 +1570,14 @@ class OSPDaemon:
         count = 0
         for scan_id in self.scan_collection.ids_iterator():
             if self.get_scan_status(scan_id) == ScanStatus.QUEUED:
+                count += 1
+        return count
+
+    def get_count_running_scans(self) -> int:
+        """ Get the amount of scans with RUNNING status """
+        count = 0
+        for scan_id in self.scan_collection.ids_iterator():
+            if self.get_scan_status(scan_id) == ScanStatus.RUNNING:
                 count += 1
         return count
 

--- a/tests/test_scan_and_result.py
+++ b/tests/test_scan_and_result.py
@@ -1496,6 +1496,79 @@ class ScanTestCase(unittest.TestCase):
         self.assertTrue(self.daemon.is_enough_free_memory())
 
     @patch("ospd.ospd.psutil")
+    def test_wait_between_scan_no_scans(self, mock_psutil):
+        # Enable option
+        self.daemon.min_free_mem_scan_queue = 1000
+        # 1.5 GB free
+        mock_psutil.virtual_memory.return_value = FakePsutil(
+            available=1500000000
+        )
+        # Not enough time between scans, but no running scan
+        self.daemon.last_scan_start_time = time.time() - 20
+
+        self.assertTrue(self.daemon.is_enough_free_memory())
+
+    @patch("ospd.ospd.psutil")
+    def test_wait_between_scan_run_scans_not_allow(self, mock_psutil):
+        # Enable option
+        self.daemon.min_free_mem_scan_queue = 1000
+        # 1.5 GB free
+        mock_psutil.virtual_memory.return_value = FakePsutil(
+            available=1500000000
+        )
+
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan>'
+            '<scanner_params /><vts><vt id="1.2.3.4" />'
+            '</vts>'
+            '<targets><target>'
+            '<hosts>localhosts,192.168.0.0/24</hosts>'
+            '<ports>80,443</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+
+        # There is a running scan
+        self.daemon.start_queued_scans()
+
+        # Not enough time between scans
+        self.daemon.last_scan_start_time = time.time() - 20
+
+        self.assertFalse(self.daemon.is_enough_free_memory())
+
+    @patch("ospd.ospd.psutil")
+    def test_wait_between_scan_allow(self, mock_psutil):
+        # Enable option
+        self.daemon.min_free_mem_scan_queue = 1000
+        # 1.5 GB free
+        mock_psutil.virtual_memory.return_value = FakePsutil(
+            available=1500000000
+        )
+
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan>'
+            '<scanner_params /><vts><vt id="1.2.3.4" />'
+            '</vts>'
+            '<targets><target>'
+            '<hosts>localhosts,192.168.0.0/24</hosts>'
+            '<ports>80,443</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+
+        # There is a running scan, enough memory and enough time
+        # in between
+        self.daemon.start_queued_scans()
+
+        self.daemon.last_scan_start_time = time.time() - 65
+
+        self.assertTrue(self.daemon.is_enough_free_memory())
+
+    @patch("ospd.ospd.psutil")
     def test_free_memory_false(self, mock_psutil):
         self.daemon.min_free_mem_scan_queue = 2000
         # 1.5 GB free
@@ -1522,6 +1595,24 @@ class ScanTestCase(unittest.TestCase):
         self.assertEqual(self.daemon.get_count_queued_scans(), 1)
         self.daemon.start_queued_scans()
         self.assertEqual(self.daemon.get_count_queued_scans(), 0)
+
+    def test_count_running_scans(self):
+        fs = FakeStream()
+        self.daemon.handle_command(
+            '<start_scan>'
+            '<scanner_params /><vts><vt id="1.2.3.4" />'
+            '</vts>'
+            '<targets><target>'
+            '<hosts>localhosts,192.168.0.0/24</hosts>'
+            '<ports>80,443</ports>'
+            '</target></targets>'
+            '</start_scan>',
+            fs,
+        )
+
+        self.assertEqual(self.daemon.get_count_running_scans(), 0)
+        self.daemon.start_queued_scans()
+        self.assertEqual(self.daemon.get_count_running_scans(), 1)
 
     def test_ids_iterator_dict_modified(self):
         self.daemon.scan_collection.scans_table = {'a': 1, 'b': 2}


### PR DESCRIPTION
**What**:
￼Wait a minute between scans starts.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Currently the queue system in ospd prevents to start a new scan if there is not enough available memory. This produces that new scans are put in the queue, while the memory condition is not satisfied.
Once some memory is released, all scans in queue are started. In the issue mentioned above, I pasted what I found in the log.
<!-- Why are these changes necessary? -->

**How**:
- Set min_free_mem_scan_queue option to some value, to avoid starting scans.
- Start many task
- release memory to allow queued scans to start.
- Check in the log that the time between takes about a minute, and the queued scans are not started all together. 


<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
