### PR TITLE
Remove the pid file if there is no process for the pid or the process name does not match.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
-Do not start all queued scans simultaneously once available memory is enough. [#401](https://github.com/greenbone/ospd/pull/401)
+- Do not start all queued scans simultaneously once available memory is enough. [#401](https://github.com/greenbone/ospd/pull/401)
+- Remove the pid file if there is no process for the pid or the process name does not match. [#405](https://github.com/greenbone/ospd/pull/405)
 
 [Unreleased]: https://github.com/greenbone/ospd/compare/v20.8.2...HEAD
 


### PR DESCRIPTION
**What**:
Remove the pid file if there is no process for the pid or the process name does not match.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
To avoid removing the pidfile manually when ospd scanner was killed or stopped abruptly.
<!-- Why are these changes necessary? -->

**How**:
- Start ospd-openvas. Try start it again. It should not be possible.
- Killall -9 ospd-openvas
- check that the pid file still exists but there is no process
- start ospd-openvas. The daemon should be started and the pid file should contain the pid of the running ospd-openvas.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
