### PR TITLE
Fix regex of gvmcg titles for get_performance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Do not start all queued scans simultaneously once available memory is enough. [#401](https://github.com/greenbone/ospd/pull/401)
 - Remove the pid file if there is no process for the pid or the process name does not match. [#405](https://github.com/greenbone/ospd/pull/405)
+- Fix regex of gvmcg titles for get_performance command. [#413](https://github.com/greenbone/ospd/pull/413)
 
 [Unreleased]: https://github.com/greenbone/ospd/compare/v20.8.2...HEAD
 

--- a/ospd/command/command.py
+++ b/ospd/command/command.py
@@ -162,21 +162,21 @@ class GetVersion(BaseCommand):
 
 
 GVMCG_TITLES = [
-    'cpu-*',
+    'cpu-.*',
     'proc',
     'mem',
     'swap',
     'load',
-    'df-*',
+    'df-.*',
     'disk-sd[a-z][0-9]-rw',
     'disk-sd[a-z][0-9]-load',
     'disk-sd[a-z][0-9]-io-load',
-    'interface-eth*-traffic',
-    'interface-eth*-err-rate',
-    'interface-eth*-err',
-    'sensors-*_temperature-*',
-    'sensors-*_fanspeed-*',
-    'sensors-*_voltage-*',
+    'interface-eth.*-traffic',
+    'interface-eth.*-err-rate',
+    'interface-eth.*-err',
+    'sensors-.*_temperature-.*',
+    'sensors-.*_fanspeed-.*',
+    'sensors-.*_voltage-.*',
     'titles',
 ]  # type: List[str]
 


### PR DESCRIPTION
**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

Fix regex of gvmcg titles for get_performance command

**Why**:

<!-- Why are these changes necessary? -->

To get expected behavior.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

```
gvm-cli --protocol OSP socket --socketpath=/run/ospd/openvas.sock --xml "<get_performance start='0' titles='interface-eth0-err'/>"
```

You will get `status_text="Arguments not allowed"` before applied PR. After you will probably get `No such file or directory: 'gvmcg': 'gvmcg'` but thats fine and expected if you do not have it installed.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
