### PR TITLE
Use better defaults for file paths and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 ### Changed
+- Use better defaults for file paths and permissions [#429](https://github.com/greenbone/ospd/pull/429)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/ospd/parser.py
+++ b/ospd/parser.py
@@ -22,19 +22,19 @@ from pathlib import Path
 from ospd.config import Config
 
 # Default file locations as used by a OpenVAS default installation
-DEFAULT_KEY_FILE = "/usr/var/lib/gvm/private/CA/serverkey.pem"
-DEFAULT_CERT_FILE = "/usr/var/lib/gvm/CA/servercert.pem"
-DEFAULT_CA_FILE = "/usr/var/lib/gvm/CA/cacert.pem"
+DEFAULT_KEY_FILE = "/var/lib/gvm/private/CA/serverkey.pem"
+DEFAULT_CERT_FILE = "/var/lib/gvm/CA/servercert.pem"
+DEFAULT_CA_FILE = "/var/lib/gvm/CA/cacert.pem"
 
 DEFAULT_PORT = 0
 DEFAULT_ADDRESS = "0.0.0.0"
 DEFAULT_NICENESS = 10
-DEFAULT_UNIX_SOCKET_MODE = "0o700"
+DEFAULT_UNIX_SOCKET_MODE = "0o770"
 DEFAULT_CONFIG_PATH = "~/.config/ospd.conf"
 DEFAULT_LOG_CONFIG_PATH = "~/.config/ospd-logging.conf"
-DEFAULT_UNIX_SOCKET_PATH = "/var/run/ospd/ospd.sock"
-DEFAULT_PID_PATH = "/var/run/ospd.pid"
-DEFAULT_LOCKFILE_DIR_PATH = "/var/run/ospd"
+DEFAULT_UNIX_SOCKET_PATH = "/run/ospd/ospd.sock"
+DEFAULT_PID_PATH = "/run/ospd/ospd.pid"
+DEFAULT_LOCKFILE_DIR_PATH = "/run/ospd"
 DEFAULT_STREAM_TIMEOUT = 10  # ten seconds
 DEFAULT_SCANINFO_STORE_TIME = 0  # in hours
 DEFAULT_MAX_SCAN = 0  # 0 = disable


### PR DESCRIPTION
**What**:

* /var/run is just a symlink to /run nowadays.
* Allow user and group to access to socket by default. This allows for
  querying data from osp in a multi-user setup more easily.
* Move pid file within /run/ospd
* There is no /usr/var directory by default. Therefore change the path
  to the certs to something that makes sense

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
