### PR TITLE
Downgrade required version for psutil to 5.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Changed
 - Use better defaults for file paths and permissions [#429](https://github.com/greenbone/ospd/pull/429)
+- Downgrade required version for psutil to 5.5.1 [#453](https://github.com/greenbone/ospd/pull/453)
 
 ### Deprecated
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.7"
-psutil = "^5.7.2"
+psutil = "^5.5.1"
 lxml = "^4.5.2"
 defusedxml = ">=0.6,<0.8"
 paramiko = "^2.7.1"


### PR DESCRIPTION
**What**:
Downgrade required version for psutil to 5.5.1
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
Because the referecen system Debian Buster offers this version.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
