### PR TITLE
Remove prefix from module list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,9 @@ and the fingerprint is `8AE4 BE42 9B60 A59B 311C  2E73 9823 FAA6 0ED1 E580`.
 
 ospd requires Python >= 3.7 along with the following libraries:
 
-    - python3-paramiko
-
-    - python3-lxml
-
-    - python3-defusedxml
+- paramiko
+- lxml
+- defusedxml
 
 ### Install using pip
 


### PR DESCRIPTION
**What**:

Remove prefix from module list and update formatting from code block to MD list.

**Why**:

The prefix (e.g., `python3-` or `py3-`) depends on the distribution what is providing the packages. PyPI doesn't have a prefix.

**How**:

N/A

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry N/A
