### PR TITLE
Fix resume task.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 ### Removed
 ### Fixed
+- Fix resume scan. [#464](https://github.com/greenbone/ospd/pull/464)
+
 
 [Unreleased]: https://github.com/greenbone/ospd/compare/v21.4.3...HEAD
 

--- a/ospd/scan.py
+++ b/ospd/scan.py
@@ -502,7 +502,17 @@ class ScanCollection:
     def get_host_list(self, scan_id: str) -> Dict:
         """ Get a scan's host list. """
 
-        return self.scans_table[scan_id]['target'].get('hosts')
+        target = None
+        try:
+            target = self.scans_table[scan_id]['target'].get('hosts')
+        except KeyError:
+            LOGGER.warning(
+                '%s: Scan ID is in the scan table, but it was '
+                'not initialized.',
+                scan_id,
+            )
+
+        return target
 
     def get_host_count(self, scan_id: str) -> int:
         """ Get total host count in the target. """


### PR DESCRIPTION
**What**:
Fix resume task
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
In some cases, the task is stopped and quickly resumed. In this cases there was race condition
in which the scan id is present in the scan table but there is no target information.
Although the quick resume can lead first into a stopped and scan followed by an interrupted scan,
finally the scan can be resumed.
<!-- Why are these changes necessary? -->

**How**:
Start, stop and resume task, until you get the interrupted scan. With the patch, resuming the task should finally work and the scan should end successfully.
<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [X] [CHANGELOG](https://github.com/greenbone/ospd/blob/master/CHANGELOG.md) Entry
